### PR TITLE
Restore functionality of fullscreen button for Flash Player on Drupal 7

### DIFF
--- a/src/js/mep-feature-fullscreen.js
+++ b/src/js/mep-feature-fullscreen.js
@@ -171,7 +171,8 @@
 						}
 
 						// on hover, kill the fullscreen button's HTML handling, allowing clicks down to Flash
-						fullscreenBtn.on('mouseover',function() {
+						fullscreenBtn 
+							.mouseover(function() {
 
 							if (!t.isFullScreen) {
 
@@ -244,7 +245,7 @@
 						// the hover state will show the fullscreen button in Flash to hover up and click
 
 						fullscreenBtn
-							.on('mouseover', function() {
+							.mouseover(function() {
 
 								if (hideTimeout !== null) {
 									clearTimeout(hideTimeout);
@@ -257,7 +258,7 @@
 								media.positionFullscreenButton(buttonPos.left - containerPos.left, buttonPos.top - containerPos.top, true);
 
 							})
-							.on('mouseout', function() {
+							.mouseout(function() {
 
 								if (hideTimeout !== null) {
 									clearTimeout(hideTimeout);


### PR DESCRIPTION
As Drupal 7's built-in jQuery is stuck at v1.4.4, recent code changes to mep-feature-fullscreen.js seem to prevent the fullscreen button from working when the Adobe Flash Player is used. This reverts some of the code back to pre-v2.12.0 to allow the fullscreen button to work with Drupal 7.

I understand MediaElement.js is not built against such an old version of jQuery and backward-compatibility may not be high on the agenda or form part of the goals of this project. But it would be ideal if it can be done.

As with my previous pull requests, my usual caveat applies: I'm new to git/github and I'm not a coder, so feel free to make changes as you see fit. These changes have been tested and work for my specific use cases.