### PR TITLE
Switch to youtube iframe api

### DIFF
--- a/src/js/me-plugindetector.js
+++ b/src/js/me-plugindetector.js
@@ -5,6 +5,9 @@ mejs.PluginDetector = {
 	// main public function to test a plug version number PluginDetector.hasPluginVersion('flash',[9,0,125]);
 	hasPluginVersion: function(plugin, v) {
 		var pv = this.plugins[plugin];
+		if (!pv) {
+			return true;
+		}
 		v[1] = v[1] || 0;
 		v[2] = v[2] || 0;
 		return (pv[0] > v[0] || (pv[0] == v[0] && pv[1] > v[1]) || (pv[0] == v[0] && pv[1] == v[1] && pv[2] >= v[2])) ? true : false;

--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -689,7 +689,8 @@ mejs.YouTubeApi = {
 	loadIframeApi: function() {
 		if (!this.isIframeStarted) {
 			var tag = document.createElement('script');
-			tag.src = "//www.youtube.com/player_api";
+			tag.src = "//www.youtube.com/iframe_api";
+			// XXX for IE version < 8 without postMessage, use //www.youtube.com/player_api
 			var firstScriptTag = document.getElementsByTagName('script')[0];
 			firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 			this.isIframeStarted = true;
@@ -893,7 +894,11 @@ mejs.YouTubeApi = {
 		
 	}
 }
-// IFRAME
+// IFRAME API
+function onYouTubeIframeAPIReady() {
+	mejs.YouTubeApi.iFrameReady();
+}
+// PLAYER API
 function onYouTubePlayerAPIReady() {
 	mejs.YouTubeApi.iFrameReady();
 }


### PR DESCRIPTION
This allows users to to embed youtube without the flashmediaelement.swf file, by using the [youtube iframe api](https://developers.google.com/youtube/iframe_api_reference).  The embed player itself is by default still flash, but on chrome if you disable the flash plugin, it loads the html5 player.

By default the flash plugin is still used, as the default plugin priority use flash > youtube.  But if your mediaelement option is set to ['youtube', 'flash'], you should be all set.

This will breaks IE7 since the iframe api requires iframe postMessage.  But it's a matter of detecting IE version and fallback to either the play_api or the mediaelement flash plugin.
