### PR TITLE
Add canBePausedByOtherPlayers option

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -72,6 +72,9 @@
 
 		// whenthis player starts, it will pause other players
 		pauseOtherPlayers: true,
+		
+		// whether this player can be paused by other players
+		canBePausedByOtherPlayers: true,
 
 		// array of keyboard actions such as play pause
 		keyActions: [
@@ -632,7 +635,7 @@
 					// go through all other players
 					for (playerIndex in mejs.players) {
 						var p = mejs.players[playerIndex];
-						if (p.id != t.id && t.options.pauseOtherPlayers && !p.paused && !p.ended) {
+						if (p.id != t.id && t.options.pauseOtherPlayers && !p.paused && !p.ended && p.options.canBePausedByOtherPlayers) {
 							p.pause();
 						}
 						p.hasFocus = false;


### PR DESCRIPTION
Hi, 

This pull request adds a simple functionality to control whether a player can be paused by other players. This is useful for certain cases like a background video, that needs to keep running when an other inline player is started.

I hope this can be added to the next release!

Thanks!