### PR TITLE
Ensure screen reader text is hidden on long pages.

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -2,6 +2,7 @@
 /* Accessibility: hide screen reader texts (and prefer "top" for RTL languages). */
 	position: absolute !important;
 	top: -10000px;
+	left: -10000px;
 	overflow: hidden;
 	width: 1px;
 	height: 1px;


### PR DESCRIPTION
On long pages, the screen reader text will be visible and overlap other elements
on the page since it only uses a negative top offset. Adding a large, negative
left offset should help ensure it's never visible.