### PR TITLE
Update me-shim.js

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -628,7 +628,7 @@ mejs.HtmlMediaElementShim = {
 				if (typeof($f) == 'function') { // froogaloop available
 					var player = $f(container.childNodes[0]);
 					player.addEvent('ready', function() {
-						$.extend( player, {
+						mejs.$.extend( player, {
 							playVideo: function() {
 								player.api( 'play' );
 							}, 


### PR DESCRIPTION
Since this file does not have an IIFE injecting `$`, this should invoke `extend` from the the `mejs.$` static reference. WordPress loads jQuery in No Conflict mode, so `$` is not available in this scope.

I added support for Vimeo via the WordPress video shortcode here:
https://github.com/WordPress/WordPress/commit/952a5c997125abb5c6f4e30b5777426d11b210ab