### PR TITLE
Bug #1397, Fix for screen reader accessibility of captions (#1340)

### DIFF
--- a/src/js/mep-feature-tracks.js
+++ b/src/js/mep-feature-tracks.js
@@ -7,6 +7,10 @@
 
 		tracksText: mejs.i18n.t('Captions/Subtitles'),
 
+		// By default, no WAI-ARIA live region - don't make a
+		// screen reader speak captions over an audio track.
+		tracksAriaLive: false,
+
 		// option to remove the [cc] button when no <track kind="subtitles"> are present
 		hideCaptionsButtonWhenEmpty: true,
 
@@ -26,6 +30,8 @@
 				return;
 
 			var t = this,
+				attr = t.options.tracksAriaLive ?
+					'role="log" aria-live="assertive" aria-atomic="false"' : '',
 				i,
 				options = '';
 
@@ -38,7 +44,8 @@
 					$('<div class="mejs-chapters mejs-layer"></div>')
 						.prependTo(layers).hide();
 			player.captions =
-					$('<div class="mejs-captions-layer mejs-layer"><div class="mejs-captions-position mejs-captions-position-hover" role="log" aria-live="assertive" aria-atomic="false"><span class="mejs-captions-text"></span></div></div>')
+					$('<div class="mejs-captions-layer mejs-layer"><div class="mejs-captions-position mejs-captions-position-hover" ' +
+					attr + '><span class="mejs-captions-text"></span></div></div>')
 						.prependTo(layers).hide();
 			player.captionsText = player.captions.find('.mejs-captions-text');
 			player.captionsButton =


### PR DESCRIPTION
Hi @johndyer (and @rylan),

Please review and pull when you have a chance. Commentary is in #1397.

Best wishes,

Thanks Nick

---
* Add a flag, so captions are not a [WAI-ARIA live region](http://w3.org/WAI/PF/aria-practices/#LiveRegions) by default