### PR TITLE
CC list refresh feature

### DIFF
--- a/src/js/mep-feature-tracks.js
+++ b/src/js/mep-feature-tracks.js
@@ -21,6 +21,14 @@
 
 		hasChapters: false,
 
+		cleartracks: function(player, controls, layers, media){
+			if(player) {
+				if(player.captions) player.captions.remove();
+				if(player.chapters) player.chapters.remove();
+				if(player.captionsText) player.captionsText.remove();
+				if(player.captionsButton) player.captionsButton.remove();
+			}
+		},
 		buildtracks: function(player, controls, layers, media) {
 			if (player.tracks.length === 0)
 				return;
@@ -34,6 +42,7 @@
 					t.domNode.textTracks[i].mode = "hidden";
 				}
 			}
+			t.cleartracks(player, controls, layers, media);
 			player.chapters =
 					$('<div class="mejs-chapters mejs-layer"></div>')
 						.prependTo(layers).hide();

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1262,6 +1262,11 @@
 			}
 			t.globalUnbind();
 			delete t.node.player;
+		},
+		rebuildtracks: function(){
+			var t = this;
+			t.findTracks();
+			t.buildtracks(t, t.controls, t.layers, t.media);
 		}
 	};
 


### PR DESCRIPTION
This adds ability to refresh the tracks list (CC) on the media element player, useful when video and tracks are changed.

`this.mep.rebuildtracks();`