### PR TITLE
Can't initialize MediaElement on a virtual DOM in IE8 and lower.

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -460,7 +460,7 @@ mejs.HtmlMediaElementShim = {
 
 		// check for placement inside a <p> tag (sometimes WYSIWYG editors do this)
 		node = htmlMediaElement.parentNode;
-		while (node !== null && node.tagName && node.tagName.toLowerCase() !== 'body' && node.parentNode != null && node.parentNode.tagName) {
+		while (node !== null && node.tagName !== null && node.tagName.toLowerCase() !== 'body' && node.parentNode !== null && node.parentNode.tagName !== null) {
 			if (node.parentNode.tagName.toLowerCase() === 'p') {
 				node.parentNode.parentNode.insertBefore(node, node.parentNode);
 				break;

--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -460,7 +460,7 @@ mejs.HtmlMediaElementShim = {
 
 		// check for placement inside a <p> tag (sometimes WYSIWYG editors do this)
 		node = htmlMediaElement.parentNode;
-		while (node !== null && node.tagName !== null && node.tagName.toLowerCase() !== 'body' && node.parentNode !== null && node.parentNode.tagName !== null) {
+		while (node !== null && node.tagName != null && node.tagName.toLowerCase() !== 'body' && node.parentNode != null && node.parentNode.tagName != null) {
 			if (node.parentNode.tagName.toLowerCase() === 'p') {
 				node.parentNode.parentNode.insertBefore(node, node.parentNode);
 				break;

--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -460,7 +460,7 @@ mejs.HtmlMediaElementShim = {
 
 		// check for placement inside a <p> tag (sometimes WYSIWYG editors do this)
 		node = htmlMediaElement.parentNode;
-		while (node !== null && node.tagName.toLowerCase() !== 'body' && node.parentNode != null) {
+		while (node !== null && node.tagName && node.tagName.toLowerCase() !== 'body' && node.parentNode != null && node.parentNode.tagName) {
 			if (node.parentNode.tagName.toLowerCase() === 'p') {
 				node.parentNode.parentNode.insertBefore(node, node.parentNode);
 				break;


### PR DESCRIPTION
When MediaElement transverses the DOM looking for a parent `<p>` tag, it explicitly looks for `node.tagName != 'body'` and `node.parentNode !== null` to avoid cases where the parentNode is the body element, or it doesn't have a parent.
Under most browsers, this is fine, however under IE8 the `parentNode` property can be set to a `DocumentFragment` which has no `tagName` or parents, which causes a JS Error.
By checking that `node.tagName` and `node.parentNode.tagName` exist, it allows MediaElement to operate under IE8 properly.

WordPress ran into this issue where we create MediaElements on a Backbone object during `render()`, at that point it's not yet been inserted into the DOM. See https://core.trac.wordpress.org/ticket/31058 for details, props @afercia for the original patch and testing.

A simple method to duplicate it is the following, which will work in Chrome & IE9, but not IE8.
```<script>
jQuery(document).ready(function($) {
	var $body = $('body');

	var $audio = $('<div class="wp-media-wrapper"><audio style="visibility: hidden" controls class="wp-audio-shortcode" width="100%" preload="none"><source type="audio/mp3" src="Audiobeast.mp3"/></audio></div>');

	$audio.find( 'audio' ).each( function( i, el ) {
		$( el ).mediaelementplayer();
	} );

	$audio.appendTo( $body );
});
</script>