### PR TITLE
Add Source Chooser into grunt (from PR #374)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,8 @@ module.exports = function(grunt) {
                     'src/js/mep-feature-speed.js',
                     'src/js/mep-feature-tracks.js',
                     'src/js/mep-feature-contextmenu.js',
-                    'src/js/mep-feature-postroll.js'
+                    'src/js/mep-feature-postroll.js',
+                    'src/js/mep-feature-sourcechooser.js'
                 ],
                 dest: 'local-build/mediaelementplayer.js'
             },

--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ In very rare cases, you might have an non-HTML5 browser with Flash turned on and
 </video>
 ```
 
+#### Optional: Source chooser for resolutions/formats
+This features enables the user to choose the resolution/format of the video playing.
+```html
+<video width="360" height="240" controls="controls">
+        <source type="video/mp4" src="myvideo_320p.mp4" title="320p mp4"/>
+        <source type="video/mp4" src="myvideo_720p.mp4" title="720p mp4"/>
+        <source type="video/webm" src="myvideo.webm" />
+        <source type="video/ogg" src="myvideo.ogv" />
+</video>
+
+<script>
+$('audio,video').mediaelementplayer({
+	features: ['playpause','progress','volume','sourcechooser']
+});
+</script>
+```
+
 ### 3. Startup
 
 #### Automatic start


### PR DESCRIPTION
It looks like the source chooser feature was added in pull request #374, but it was never added to grunt. I believe this was an oversight as currently the demo page for mediaelementplayer-sourcechooser.html does not work.