### PR TITLE
Fixed error display when source not available

### DIFF
--- a/build/mediaelement-and-player.js
+++ b/build/mediaelement-and-player.js
@@ -3047,7 +3047,7 @@ if (typeof jQuery != 'undefined') {
 				loading.hide();
 				controls.find('.mejs-time-buffering').hide();
 				error.show();
-				error.find('mejs-overlay-error').html("Error loading this resource");
+				error.find('.mejs-overlay-error').html("Error loading this resource");
 			}, false);
 
 			media.addEventListener('keydown', function(e) {


### PR DESCRIPTION
For now, no error message was displayed when an error was raised.