### PR TITLE
canPlayAfterSourceSwitchHandler is fired twice

### DIFF
--- a/src/js/mep-feature-sourcechooser.js
+++ b/src/js/mep-feature-sourcechooser.js
@@ -45,7 +45,7 @@
 								if (!paused) {
 									media.play();
 								}
-								media.removeEventListener("canplay", canPlayAfterSourceSwitchHandler);
+								media.removeEventListener("canplay", canPlayAfterSourceSwitchHandler, true);
 							};
 							media.addEventListener('canplay', canPlayAfterSourceSwitchHandler, true);
 							media.load();


### PR DESCRIPTION
Since we put the parameter useCapture as true there:
media.addEventListener('canplay', canPlayAfterSourceSwitchHandler, true);

We would need to set the same value on removeEventListener. Otherwise, the function would be fired twice.