### PR TITLE
Fixed error display when source not available

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1114,7 +1114,7 @@
 				loading.hide();
 				controls.find('.mejs-time-buffering').hide();
 				error.show();
-				error.find('mejs-overlay-error').html("Error loading this resource");
+				error.find('.mejs-overlay-error').html("Error loading this resource");
 			}, false);
 
 			media.addEventListener('keydown', function(e) {


### PR DESCRIPTION
For now, no error message was displayed when an error was raised.