### PR TITLE
[fix #1450] Avoid an error when there are no controls in the control bar

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -949,7 +949,7 @@
 				total.width(railWidth - (total.outerWidth(true) - total.width()));
 
 				if (lastControl.css('position') != 'absolute') {
-					lastControlPosition = lastControl.position();
+					lastControlPosition = lastControl.length ? lastControl.position() : null;
 					railWidth--;
 				}
 			} while (lastControlPosition !== null && lastControlPosition.top > 0 && railWidth > 0);


### PR DESCRIPTION
This fixes issue #1450 