### PR TITLE
Fix #1499 Play button and loading animation not aligned.

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -890,13 +890,6 @@
 
 			}
 
-			// special case for big play button so it doesn't go over the controls area
-			var playLayer = t.layers.find('.mejs-overlay-play'),
-				playButton = playLayer.find('.mejs-overlay-button');
-
-			playLayer.height(t.container.height() - t.controls.height());
-			playButton.css('margin-top', '-' + (playButton.height()/2 - t.controls.height()/2).toString() + 'px'  );
-
 		},
 
 		setControlsSize: function() {


### PR DESCRIPTION
Remove code that tries to dynamically modify the CSS height of mejs-overlay-play and mejs-overlay-button.
According to the comment, that code is intended for "special case for big play button so it doesn't go over the controls area". However, the code fails to achieve that: even with that code removed, the initial vertical position of the play button remains unchanged. Plus, it fixes the bug mentioned above.