### PR TITLE
Fix for spacebar bug

### DIFF
--- a/build/mediaelement-and-player.js
+++ b/build/mediaelement-and-player.js
@@ -2020,9 +2020,9 @@ if (typeof jQuery != 'undefined') {
 							  ],
 						action: function(player, media) {
 								if (media.paused || media.ended) {
-										player.play();
+										media.play();
 								} else {
-										player.pause();
+										media.pause();
 								}
 						}
 				},

--- a/build/mediaelement-and-player.js
+++ b/build/mediaelement-and-player.js
@@ -2020,9 +2020,9 @@ if (typeof jQuery != 'undefined') {
 							  ],
 						action: function(player, media) {
 								if (media.paused || media.ended) {
-										media.play();
+										player.play();
 								} else {
-										media.pause();
+										player.pause();
 								}
 						}
 				},

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -85,9 +85,9 @@
 							  ],
 						action: function(player, media) {
 								if (media.paused || media.ended) {
-										player.play();
+										media.play();
 								} else {
-										player.pause();
+										media.pause();
 								}
 						}
 				},


### PR DESCRIPTION
When spacebar is pressed to play a paused video it resets the video to the beginning because player.play() has the line this.load(). This fixes the issue by running media.play() instead of player.play().