### PR TITLE
Improved max-width test for MediaElementPlayer.setPlayerSize

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -810,7 +810,7 @@
 			}
 
 			// detect 100% mode - use currentStyle for IE since css() doesn't return percentages
-			if (t.height.toString().indexOf('%') > 0 || t.$node.css('max-width') === '100%' || (t.$node[0].currentStyle && t.$node[0].currentStyle.maxWidth === '100%')) {
+			if (t.height.toString().indexOf('%') > 0 || (t.$node.css('max-width') !== 'none' && t.$node.css('max-width') !== 't.width') || (t.$node[0].currentStyle && t.$node[0].currentStyle.maxWidth === '100%')) {
 
 				// do we have the native dimensions yet?
 				var nativeWidth = (function() {


### PR DESCRIPTION
The test for max-width in MediaElementPlayer.setPlayerSize only returns true if max-width is set to 100%. Firefox returns the calculated value instead, so this check always fails in FF. A different, solution is to simply check if a max-width is set and if that value is different than the width of the video, in which case it should probably be resized. This should resolve #920.