### PR TITLE
Use more appropriate MediaElement events from spec

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1087,36 +1087,24 @@
 
 
 			// show/hide loading
-			media.addEventListener('loadeddata',function() {
-				// for some reason Chrome is firing this event
-				//if (mejs.MediaFeatures.isChrome && media.getAttribute && media.getAttribute('preload') === 'none')
-				//	return;
-
+			media.addEventListener('loadstart',function() {
 				loading.show();
 				controls.find('.mejs-time-buffering').show();
-                // Firing the 'canplay' event after a timeout which isn't getting fired on some Android 4.1 devices (https://github.com/johndyer/mediaelement/issues/1305)
-                if (mejs.MediaFeatures.isAndroid) {
-                    media.canplayTimeout = window.setTimeout(
-                        function() {
-                            if (document.createEvent) {
-                                var evt = document.createEvent('HTMLEvents');
-                                evt.initEvent('canplay', true, true);
-                                return media.dispatchEvent(evt);
-                            }
-                        }, 300
-                    );
-                }
 			}, false);
+			media.addEventListener('loadeddata',function() {
+				loading.hide();
+				controls.find('.mejs-time-buffering').hide();
+ 			}, false);
 			media.addEventListener('canplay',function() {
 				loading.hide();
 				controls.find('.mejs-time-buffering').hide();
-                clearTimeout(media.canplayTimeout); // Clear timeout inside 'loadeddata' to prevent 'canplay' to fire twice
 			}, false);
 
 			// error handling
-			media.addEventListener('error',function() {
+			media.addEventListener('error',function(e) {
+				t.handleError(e);
 				loading.hide();
-				controls.find('.mejs-time-buffering').hide();
+				bigPlay.hide();
 				error.show();
 				error.find('.mejs-overlay-error').html("Error loading this resource");
 			}, false);


### PR DESCRIPTION
Using the `loadstart` and `loadeddata` events from the spec appears to take care of browser issues with the loading indicator not being hidden. The latter should be an indication that the video is play ready 

A media error should be propagated to player error handler and hide the `bigPlay` layer.