### PR TITLE
Added missing license field for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mediaelement",
+  "license": "MIT",
   "version": "2.17.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding a license field makes the license show up on NPM and other places that rely on the package metadata.