### PR TITLE
Added missing main field for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mediaelement",
   "version": "2.17.0",
+  "main": "build/mediaelement.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/johndyer/mediaelement.git"


### PR DESCRIPTION
Currently you have to use `require("mediaelement/build/mediaelement")` to load the module in browserify. With this change all you need is `require("mediaelement")` (assuming a browser environment).