### PR TITLE
Added player.js

### DIFF
--- a/player.js
+++ b/player.js
@@ -1,0 +1,1 @@
+module.exports = require('./build/mediaelementplayer.js');


### PR DESCRIPTION
This allows using `require("mediaelement/player")` instead of `require("mediaelement/build/mediaelementplayer")` in browserify.