### PR TITLE
add Zepto support to MediaElement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ newfeatures/*
 /mejs3/
 node_modules
 local-build
+# PhpStorm/WebStorm configuration
+.idea

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -177,4 +177,6 @@ module.exports = function(grunt) {
     grunt.registerTask('default', ['concat', 'removelogging', 'uglify', 'cssmin', 'copy',
         'shell:buildFlash', 'replace:cdnBuild', 'shell:buildFlashCDN', 'clean:temp']);
 
+    grunt.registerTask('html5only', ['concat', 'removelogging', 'uglify', 'cssmin', 'copy', 'clean:temp']);
+
 };

--- a/src/js/mep-feature-progress.js
+++ b/src/js/mep-feature-progress.js
@@ -44,9 +44,11 @@
                         x;
                     
                     // mouse or touch position relative to the object
-					if (e.originalEvent.changedTouches) {
+					if (e.originalEvent && e.originalEvent.changedTouches) {
 						x = e.originalEvent.changedTouches[0].pageX;
-					}else{
+					} else if (e.changedTouches) { // for Zepto
+						x = e.changedTouches[0].pageX;
+					} else {
 						x = e.pageX;
 					}
 

--- a/src/js/mep-library.js
+++ b/src/js/mep-library.js
@@ -1,5 +1,18 @@
 if (typeof jQuery != 'undefined') {
 	mejs.$ = jQuery;
+} else if (typeof Zepto != 'undefined') {
+	mejs.$ = Zepto;
+
+	// define `outerWidth` method which has not been realized in Zepto
+	$.fn.outerWidth = function(includeMargin) {
+		var width = $(this).width();
+		if (includeMargin) {
+			width += parseInt($(this).css('margin-right'), 10);
+			width += parseInt($(this).css('margin-left'), 10);
+		}
+		return width
+	}
+
 } else if (typeof ender != 'undefined') {
 	mejs.$ = ender;
 }

--- a/src/js/mep-library.js
+++ b/src/js/mep-library.js
@@ -4,7 +4,7 @@ if (typeof jQuery != 'undefined') {
 	mejs.$ = Zepto;
 
 	// define `outerWidth` method which has not been realized in Zepto
-	$.fn.outerWidth = function(includeMargin) {
+	Zepto.fn.outerWidth = function(includeMargin) {
 		var width = $(this).width();
 		if (includeMargin) {
 			width += parseInt($(this).css('margin-right'), 10);


### PR DESCRIPTION
Zepto is a mobile-friendly library which is popular nowadays. 

Include three modules of Zepto:
- [zepto](https://github.com/madrobby/zepto/blob/master/src/zepto.js#files)
- [selector](https://github.com/madrobby/zepto/blob/master/src/selector.js#files)
- [touch](https://github.com/madrobby/zepto/blob/master/src/touch.js#files)

```
<script src="https://raw.githubusercontent.com/madrobby/zepto/master/src/zepto.js"></script>
<script src="https://raw.githubusercontent.com/madrobby/zepto/master/src/selector.js"></script>
<script src="https://raw.githubusercontent.com/madrobby/zepto/master/src/touch.js"></script>
```

And MediaElement can be powered by Zepto.