### PR TITLE
Fix for spacebar bug

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -101,9 +101,9 @@
 							  ],
 						action: function(player, media) {
 								if (media.paused || media.ended) {
-										player.play();
+										media.play();
 								} else {
-										player.pause();
+										media.pause();
 								}
 						}
 				},


### PR DESCRIPTION
When spacebar is pressed to play a paused video it resets the video to the beginning because player.play() has the line this.load(). This fixes the issue by running media.play() instead of player.play().