### PR TITLE
Fix progress bar not matching clicks

### DIFF
--- a/src/js/mep-feature-progress.js
+++ b/src/js/mep-feature-progress.js
@@ -37,7 +37,7 @@
 				handleMouseMove = function (e) {
 					
                     var offset = total.offset(),
-						width = total.outerWidth(true),
+						width = total.width(),
 						percentage = 0,
 						newTime = 0,
 						pos = 0,


### PR DESCRIPTION
Fixed the progress bar being slightly off when clicking. 

Before:
![](http://i.imgur.com/KpxtBlF.gif)

After:
![](http://i.imgur.com/0SnTcJI.gif)