### PR TITLE
Fixed blinking controls issue on Firefox

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -617,7 +617,7 @@
 
 						// show/hide controls
 						t.container
-							.bind('mouseenter mouseover', function () {
+							.bind('mouseenter', function () {
 								if (t.controlsEnabled) {
 									if (!t.options.alwaysShowControls ) {
 										t.killControlsTimer('enter');
@@ -1279,7 +1279,7 @@
 				//console.log("resetSize");
 				t.setPlayerSize(t.width, t.height);
 				t.setControlsSize();
-			}, 50);            
+			}, 50);
 		}
 	};
 


### PR DESCRIPTION
When hovering over the controls in Firefox, the mouseover event would sometimes fire on a sibling to the controls immediately after the controls disappear, causing the controls to blink back on.

By not listening to mouseover event, the problem is solved and there appear to be no other detrimental effects.

This is an update to the original PR:
https://github.com/johndyer/mediaelement/pull/1540
