### PR TITLE
Keep track of playback speed when the source changes

### DIFF
--- a/src/js/mep-feature-speed.js
+++ b/src/js/mep-feature-speed.js
@@ -90,6 +90,12 @@
 
 				playbackSpeed = t.options.defaultSpeed;
 
+				media.addEventListener('loadedmetadata', function(e) {
+					if (playbackSpeed) {
+						media.playbackRate = parseFloat(playbackSpeed);
+					}
+				}, true);
+
 				speedSelector
 					.on('click', 'input[type="radio"]', function() {
 						var newSpeed = $(this).attr('value');


### PR DESCRIPTION
If using the speed plugin with the source chooser plugin, changing the
video source caused the playback speed to revert to the default,
though the button still had the custom playback speed selected.