### PR TITLE
Maintain backward compatibility in secondsToTime() code method signature.

### DIFF
--- a/src/js/me-utility.js
+++ b/src/js/me-utility.js
@@ -141,6 +141,18 @@ mejs.Utility = {
 			time = 0;
 		}
 
+		// Maintain backward compatibility with method signature before v2.18.
+		if (typeof options !== 'object') {
+			var format = 'm:ss';
+			format = arguments[1] ? 'hh:mm:ss' : format; // forceHours
+			format = arguments[2] ? format + ':ff' : format; // showFrameCount
+
+			options = {
+				currentTimeFormat: format,
+				framesPerSecond: arguments[3] || 25
+			};
+		}
+
 		var fps = options.framesPerSecond;
 		if(typeof fps === 'undefined') {
 			fps = 25;


### PR DESCRIPTION
The method signature for mejs.Utility.secondsToTimeCode() changed in v2.18 to
allow for greater control over time formats, but the change breaks backward
compatibility and throws errors for scripts expecting the old signature.

This change detects when the method is being called with the original parameters
and converts them to the new options object.