### PR TITLE
Volume no longer disappears on blur

### DIFF
--- a/src/js/mep-feature-volume.js
+++ b/src/js/mep-feature-volume.js
@@ -224,9 +224,6 @@
 					positionVolumeHandle(volume);
 					media.setVolume(volume);
 					return false;
-				})
-				.bind('blur', function () {
-					volumeSlider.hide();
 				});
 
 			// MUTE button


### PR DESCRIPTION
When tabbing through the controls (e.g. for screenreaders, keyboard control) the volume control disappears after focus leaves. This fixes the issue.