### PR TITLE
Only focus the playbutton when the controllbar is not hidden

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -330,7 +330,7 @@
 					.addClass(t.$media[0].className)
 					.insertBefore(t.$media)
 					.focus(function ( e ) {
-						if( !t.controlsAreVisible ) {
+						if( !t.controlsAreVisible && t.controlsEnabled ) {
 							t.showControls(true);
 							var playButton = t.container.find('.mejs-playpause-button > button');
 							playButton.focus();


### PR DESCRIPTION
otherwise the controllbar is displayed although it is disabled, e.g. when playing the preroll-ads