### PR TITLE
Hide controls only when avialable

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -824,7 +824,9 @@
 		handleError: function(e) {
 			var t = this;
 
-			t.controls.hide();
+			if (t.controls) {
+				t.controls.hide();
+			}
 
 			// Tell user that the file cannot be played
 			if (t.options.error) {


### PR DESCRIPTION
handleError may be called even when there is no DOM element for the controls because the player uses native controls. Therefore the existence of this element must be checked before the player tries to hide them.