### PR TITLE
No longer clone media DOM element on iOS

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -348,22 +348,7 @@
 
 
 				// move the <video/video> tag into the right spot
-				if (mf.isiOS) {
-
-					// sadly, you can't move nodes in iOS, so we have to destroy and recreate it!
-					var $newMedia = t.$media.clone();
-
-					t.container.find('.mejs-mediaelement').append($newMedia);
-
-					t.$media.remove();
-					t.$node = t.$media = $newMedia;
-					t.node = t.media = $newMedia[0];
-
-				} else {
-
-					// normal way of moving it into place (doesn't work on iOS)
-					t.container.find('.mejs-mediaelement').append(t.$media);
-				}
+				t.container.find('.mejs-mediaelement').append(t.$media);
 
 				// needs to be assigned here, after iOS remap
 				t.node.player = t;


### PR DESCRIPTION
Fixes https://github.com/johndyer/mediaelement/issues/1660

iOS used to not allow you to move elements on the DOM, so we needed to clone, append, and then destroy an element in order to move it. This no longer appears to be the case. Also, cloning the element had unintended side effects, like losing event listeners. This commit makes `VideoElementPlayer` treat elements the same on iOS as other platforms.