### PR TITLE
add mimetype 'audio/mp4' to flash

### DIFF
--- a/src/js/me-namespace.js
+++ b/src/js/me-namespace.js
@@ -14,7 +14,7 @@ mejs.plugins = {
 		{version: [3,0], types: ['video/mp4','video/m4v','video/mov','video/wmv','audio/wma','audio/m4a','audio/mp3','audio/wav','audio/mpeg']}
 	],
 	flash: [
-		{version: [9,0,124], types: ['video/mp4','video/m4v','video/mov','video/flv','video/rtmp','video/x-flv','audio/flv','audio/x-flv','audio/mp3','audio/m4a','audio/mpeg', 'video/youtube', 'video/x-youtube', 'video/dailymotion', 'video/x-dailymotion', 'application/x-mpegURL']}
+		{version: [9,0,124], types: ['video/mp4','video/m4v','video/mov','video/flv','video/rtmp','video/x-flv','audio/flv','audio/x-flv','audio/mp3','audio/m4a', 'audio/mp4', 'audio/mpeg', 'video/youtube', 'video/x-youtube', 'video/dailymotion', 'video/x-dailymotion', 'application/x-mpegURL']}
 		//,{version: [12,0], types: ['video/webm']} // for future reference (hopefully!)
 	],
 	youtube: [


### PR DESCRIPTION
This fixed an issue I had with a flash fallback for .mp4 files that have audio-only and audio/mp4 mimetype. I also had to specify  ``pluginVars: 'isvideo=true', ``

I suppose I could have also fixed this by using ``audio/m4a`` as the mime type, but ``audio/mp4`` can also work so it seems worth including.