### PR TITLE
Fix a minor typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This includes multiple codecs for various browsers (H.264 for IE9+, Safari, and 
 ```
 
 #### Optional: Browsers with JavaScript disabled
-In very rare cases, you might have an non-HTML5 browser with Flash turned on and JavaScript turned off. In that specific case, you can also include the Flash `<object>` code.
+In very rare cases, you might have a non-HTML5 browser with Flash turned on and JavaScript turned off. In that specific case, you can also include the Flash `<object>` code.
 ```html
 <video width="320" height="240" poster="poster.jpg" controls="controls" preload="none">
 	<source type="video/mp4" src="myvideo.mp4" />


### PR DESCRIPTION
Replace `an` with `a`