### PR TITLE
Introduce enable100PercentMode option and fix 2 issues

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -572,7 +572,7 @@
 	border-radius: 0;
 }
 
-.mejs-controls .mejs-captions-button:hover  .mejs-captions-selector {
+.mejs-controls .mejs-captions-button:hover .mejs-captions-selector.mejs-captions-selector-enabled {
 	visibility: visible;
 }
 

--- a/src/js/mep-feature-tracks.js
+++ b/src/js/mep-feature-tracks.js
@@ -90,9 +90,11 @@
 					player.setTrack(lang);
 				});
 			} else {
+				var captionsSelector = player.captionsButton.find('.mejs-captions-selector');
+				captionsSelector.addClass('mejs-captions-selector-enabled');
 				// hover or keyboard focus
 				player.captionsButton.on( 'mouseenter focusin', function() {
-					$(this).find('.mejs-captions-selector').removeClass('mejs-offscreen');
+					captionsSelector.removeClass('mejs-offscreen');
 				})
 
 				// handle clicks to the language radio buttons
@@ -102,7 +104,7 @@
 				});
 
 				player.captionsButton.on( 'mouseleave focusout', function() {
-					$(this).find(".mejs-captions-selector").addClass("mejs-offscreen");
+					captionsSelector.addClass("mejs-offscreen");
 				});
 
 			}

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -19,6 +19,12 @@
 		// default if the user doesn't specify
 		defaultAudioHeight: 30,
 
+                // Possible values:
+                // null: let mediaelement decide if the 100% mode should be used
+                // true: force the 100% mode
+                // false: no 100% mode
+                enable100PercentMode: null,
+
 		// default amount to move back when back key is pressed
 		defaultSeekBackwardInterval: function(media) {
 			return (media.duration * 0.05);
@@ -841,7 +847,17 @@
                             maxWidth = maxWidth.replace(/px$/, '');
                         }
 
-                        if (t.height.toString().indexOf('%') > 0 || (maxWidth!== 'none' && maxWidth.toString() !== t.width.toString()) || (t.$node[0].currentStyle && t.$node[0].currentStyle.maxWidth === '100%')) {
+                        var use100PercentMode = function() {
+                            // check if we should use the 100% mode
+                            if (t.options.enable100PercentMode !== null) {
+                                return t.options.enable100PercentMode;
+                            }
+                            return (t.height.toString().indexOf('%') > 0 ||
+                                    (maxWidth!== 'none' && maxWidth.toString() !== t.width.toString()) ||
+                                    (t.$node[0].currentStyle && t.$node[0].currentStyle.maxWidth === '100%'));
+                        };
+
+                        if (use100PercentMode()) {
 				// do we have the native dimensions yet?
 				var nativeWidth = (function() {
 					if (t.isVideo) {

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -835,8 +835,13 @@
 			}
 
 			// detect 100% mode - use currentStyle for IE since css() doesn't return percentages
-			if (t.height.toString().indexOf('%') > 0 || (t.$node.css('max-width') !== 'none' && t.$node.css('max-width') !== 't.width') || (t.$node[0].currentStyle && t.$node[0].currentStyle.maxWidth === '100%')) {
+                        var maxWidth = t.$node.css('max-width');
+                        if (typeof(maxWidth) === 'string') {
+                            // Remove the pixel unit if present to compare correctly
+                            maxWidth = maxWidth.replace(/px$/, '');
+                        }
 
+                        if (t.height.toString().indexOf('%') > 0 || (maxWidth!== 'none' && maxWidth.toString() !== t.width.toString()) || (t.$node[0].currentStyle && t.$node[0].currentStyle.maxWidth === '100%')) {
 				// do we have the native dimensions yet?
 				var nativeWidth = (function() {
 					if (t.isVideo) {


### PR DESCRIPTION
The 100% mode didn't work as expected. I fix the existing code and introduce enable100PercentMode option to easily enable/disable it.

Also I fix an issue on the captions selector: we don't want it displayed all the times.