### PR TITLE
Pass the entire event object to the key action

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1170,7 +1170,7 @@
 					for (var j = 0, jl = keyAction.keys.length; j < jl; j++) {
 						if (e.keyCode == keyAction.keys[j]) {
 							if (typeof(e.preventDefault) == "function") e.preventDefault();
-							keyAction.action(player, media, e.keyCode);
+							keyAction.action(player, media, e.keyCode, e);
 							return false;
 						}
 					}


### PR DESCRIPTION
This way the key action handlers can make more granular decisions on when to fire based on say, `event.target`. We lose a bunch of useful information when we pass only the keyCode in.