### PR TITLE
Support for VAST3 adpods

### DIFF
--- a/src/js/me-i18n-locale-es.js
+++ b/src/js/me-i18n-locale-es.js
@@ -29,7 +29,10 @@
             "Mute" : "Silencio",
             "Turn off Fullscreen" : "Desconectar pantalla completa",
             "Go Fullscreen" : "Ir a pantalla completa",
-            "Close" : "Cerrar"
+            "Close" : "Cerrar",
+	    "Skip ad": "Salta publicidad",
+	    "Skip in": "Salta en",
+	    "seconds": "segundos"
         };
     }
 

--- a/src/js/mep-feature-ads-vast.js
+++ b/src/js/mep-feature-ads-vast.js
@@ -12,7 +12,7 @@
 	$.extend(MediaElementPlayer.prototype, {
 		buildvast: function(player, controls, layers, media) {
 
-			var t = this;			
+			var t = this;	
 			
 			// begin loading
 			if (t.options.vastAdTagUrl != '') {
@@ -33,7 +33,7 @@
 		vastStartedPlaying: false,
 		
 		vastAdTags: [],
-		
+	
 		vastSetupEvents: function() {
 			var t = this;
 			
@@ -70,8 +70,9 @@
 
 				console.log('VAST','mejsprerollended');
 				
-				if (t.vastAdTags.length > 0 && t.vastAdTags[0].trackingEvents['complete']) {
-					t.adsLoadUrl(t.vastAdTags[0].trackingEvents['complete']);
+				if (t.vastAdTags.length > 0 && t.options.indexPreroll < t.vastAdTags.length && 
+                    t.vastAdTags[t.options.indexPreroll].trackingEvents['complete']) {
+					t.adsLoadUrl(t.vastAdTags[t.options.indexPreroll].trackingEvents['complete']);
 				}
 				
 			});			
@@ -84,6 +85,7 @@
 		
 			// set and reset
 			t.options.vastAdTagUrl = url;
+			t.options.indexPreroll = 0;
 			t.vastAdTagIsLoaded = false;
 			t.vastAdTags = [];
 		},
@@ -115,7 +117,7 @@
 					t.vastParseVastData(data)				
 				},
 				error: function(err) {
-					console.log('vast:direct:error', err);
+					console.log('vast3:direct:error', err);
 					
 					// fallback to Yahoo proxy
 					t.loadAdTagInfoProxy();
@@ -153,8 +155,10 @@
 			
 			var t = this;
 			
+			
 			// clear out data
 			t.vastAdTags = [];
+			t.options.indexPreroll = 0;
 			
 			$(data).find('Ad').each(function(index, node) {
 					
@@ -230,12 +234,17 @@
 			var t = this;
 				
 			// if we have a media URL, then send it up to the ads plugin as a preroll
-			if (t.vastAdTags.length > 0 && t.vastAdTags[0].mediaFiles.length > 0) {
-				
-				t.options.adsPrerollMediaUrl = t.vastAdTags[0].mediaFiles[0].url;
-				t.options.adsPrerollAdUrl = t.vastAdTags[0].clickThrough;
-				t.adsStartPreroll();
+			// load up the vast ads to be played before the selected media.
+			// Note: multiple preroll ads are supported.
+			i = 0;
+			while (i < t.vastAdTags.length) {
+				t.options.adsPrerollMediaUrl[i] = t.vastAdTags[i].mediaFiles[0].url;
+				console.log(t.options.adsPrerollMediaUrl[i]);
+				t.options.adsPrerollAdUrl[i] = t.vastAdTags[i].clickThrough;
+				i++;
 			}
+			t.adsStartPreroll();
+			
 		}
 		
 	});


### PR DESCRIPTION
We needed a way to support more than one ad for preroll. I have updated the mep-feature-ads.js and mep-feature-ads-vast.js files to support Adpods (an array of ads). I have tested this with VAST2 and VAST3 xml files. 

I also added internationalisation for the 'Skip in' and 'Skip Ad' strings. I supplied the translation for Spanish (mep-i18n-locale-es.js). 

Lastly I fixed a small bug that opened a new window even if the clickthrough link is not defined. The application I am working on is 'offline' so we don't have clickthrough links. 