### PR TITLE
Puts source-chooser offscreen on load

### DIFF
--- a/src/js/mep-feature-sourcechooser.js
+++ b/src/js/mep-feature-sourcechooser.js
@@ -13,7 +13,7 @@
 			player.sourcechooserButton =
 				$('<div class="mejs-button mejs-sourcechooser-button">'+
 					'<button type="button" aria-controls="' + t.id + '" title="' + t.options.sourcechooserText + '" aria-label="' + t.options.sourcechooserText + '"></button>'+
-					'<div class="mejs-sourcechooser-selector">'+
+					'<div class="mejs-sourcechooser-selector mejs-offscreen">'+
 						'<ul>'+
 						'</ul>'+
 					'</div>'+


### PR DESCRIPTION
The latest changes to the source-chooser plugin make the submenu visible on load, and need an explicit `$.hover` to trigger hiding it. This PR adds the `mejs-offscreen` class on load to correct the behavior.