### PR TITLE
Fix Resize Issue in Poster Mode

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -44,6 +44,14 @@
 		// resize to media dimensions
 		enableAutosize: true,
 
+		// Instead of relying on current dimensions to resize responsive
+		// video containers in 100% mode, use a ratio for more consistent resizing.
+		useResizeRatio: false,
+
+		// The ratio value to use for resizing if useResizeRatio is enabled.
+		// This will be set automatically; no need to pass in a config value.
+		resizeRatio: null,
+
 		/*
 		 * Time format to use. Default: 'mm:ss'
 		 * Supported units:
@@ -820,7 +828,8 @@
 		},
 
 		setPlayerSize: function(width,height) {
-			var t = this;
+			var t = this,
+					useResizeRatio = t.options.useResizeRatio;
 
 			if( !t.options.setDimensions ) {
 				return false;
@@ -866,10 +875,17 @@
 					}
 				})();
 
+				// If useResizeRatio is enabled but a ratio value doesn't exist,
+				// set it using the current (initial) dimensions.
+				if (useResizeRatio && !t.options.resizeRatio) {
+					t.options.resizeRatio = nativeWidth / nativeHeight;
+				}
+
 				var
 					parentWidth = t.container.parent().closest(':visible').width(),
 					parentHeight = t.container.parent().closest(':visible').height(),
-					newHeight = t.isVideo || !t.options.autosizeProgress ? parseInt(parentWidth * nativeHeight/nativeWidth, 10) : nativeHeight;
+					newHeightRaw = useResizeRatio ? parentWidth / t.options.resizeRatio : parentWidth * nativeHeight/nativeWidth,
+					newHeight = t.isVideo || !t.options.autosizeProgress ? parseInt(newHeightRaw, 10) : nativeHeight;
 
 				// When we use percent, the newHeight can't be calculated so we get the container height
 				if (isNaN(newHeight)) {


### PR DESCRIPTION
I've encountered an issue where a responsive (100% mode) video container's height will continuously shrink when resized up and down while in the "poster" state. To address it, I've created an option called 'useResizeRatio' that grants more consistent resizing by using a fixed ratio instead of relying on it's current dimensions.

Let me know if there's a better way to handle this logic. Also, I'm happy to write tests for this feature but the testing suite seems fairly out of date at the moment (running test.html spits out resource loading errors).

Thanks for all your hard work on mediaelement!