### PR TITLE
Constrain volume to 0-1 range with arrow keys

### DIFF
--- a/src/js/mep-feature-volume.js
+++ b/src/js/mep-feature-volume.js
@@ -211,10 +211,10 @@
 					var volume = media.volume;
 					switch (keyCode) {
                         case 38: // Up
-                            volume += 0.1;
+                            volume = Math.min(volume + 0.1, 1);
                             break;
                         case 40: // Down
-                            volume = volume - 0.1;
+                            volume = Math.max(0, volume - 0.1);
                             break;
                         default:
                             return true;


### PR DESCRIPTION
This prevents console errors from happening when pressing the arrow keys attempts to push the volume below 0% or above 100%.