### PR TITLE
Fix lastControlPosition.top in browser zoom mode

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -972,7 +972,7 @@
 					lastControlPosition = lastControl.length ? lastControl.position() : null;
 					railWidth--;
 				}
-			} while (lastControlPosition !== null && lastControlPosition.top > 0 && railWidth > 0);
+			} while (lastControlPosition !== null && lastControlPosition.top.toFixed(2) > 0 && railWidth > 0);
 
 			t.container.trigger('controlsresize');
 		},


### PR DESCRIPTION
In zoom mode lastControlPosition.top may be like 0.0000030517578011313162, so I suggest to round lastControlPosition.top and not to break mejs-time-rail.
Screen: https://drive.google.com/file/d/0Bxtv10NlSOEbUUxEVWtnQVVMNzQ/view?usp=sharing