### PR TITLE
Fix 2 issues with YouTube player

### DIFF
--- a/src/js/me-mediaelements.js
+++ b/src/js/me-mediaelements.js
@@ -118,7 +118,9 @@ mejs.PluginMediaElement.prototype = {
 	pause: function () {
 		if (this.pluginApi != null) {
 			if (this.pluginType == 'youtube' || this.pluginType == 'vimeo') {
-				this.pluginApi.pauseVideo();
+		        if( this.pluginApi.getPlayerState() == 1 ) {
+				    this.pluginApi.pauseVideo();
+                }
 			} else {
 				this.pluginApi.pauseMedia();
 			}			

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -787,6 +787,7 @@
 				//  user has to start playback directly by tapping on the iFrame.
 				if (t.media.pluginType == 'youtube' && ( mf.isiOS || mf.isAndroid ) ) {
 					t.container.find('.mejs-overlay-play').hide();
+                    t.container.find('.mejs-poster').hide();
 				}
 			}
 


### PR DESCRIPTION
Both fixes deal with issues in IOS

#1 The source already has a fix in place for IOS where it hides the play button because the user needs to click on the iframe to start playing. This adds code to also hide the poster because if the poster is visible, the user can't click on the iframe.

#2 When you have multiple YouTube players and you play the first video, it goes through the other videos and pauses them (pauseOtherPlayers:true).  For some reason the YouTube player doesn't like when you pause() a video that is not playing.  The other videos on the page become non-functional when pause() is called on them.  The fix simply verifies that the player is playing before it pauses the video.

Examples of the issues:
http://output.jsbin.com/bavena
First video has the poster iamge