### PR TITLE
Handle keydown events only for focused mediaelement

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1150,7 +1150,8 @@
 
 				// listen for key presses
 				t.globalBind('keydown', function(event) {
-					player.hasFocus = $(event.target).closest('.mejs-container').length !== 0;
+					player.hasFocus = $(event.target).closest('.mejs-container').length !== 0
+						&& $(event.target).closest('.mejs-container').attr('id') === player.$media.closest('.mejs-container').attr('id');
 					return t.onkeydown(player, media, event);
 				});
 


### PR DESCRIPTION
If multiple mediaelements are included in the same page, the key events
triggered for all of them. This was caused by the fact that hasFocus was
true for every mediaelement if the focus was at any mediaelement.

This adds an additional check if the target mejs-container matches the
players mejs-container, thus hasFocus is only true for the really
focused player.

This solves the issue #1731 .

I'm not sure if this is the best way to compare the target element and the player element, it might be that better solutions exist.