### PR TITLE
Improve video ID parsing for YouTube URLs

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -594,7 +594,11 @@ mejs.HtmlMediaElementShim = {
 					}
 				}
 				else {
-					videoId = playback.url.substr(playback.url.lastIndexOf('=')+1);
+					// https://www.youtube.com/watch?v=
+					var videoIdMatch = playback.url.match( /[?&]v=([^&#]+)|&|#|$/ );
+					if ( videoIdMatch ) {
+						videoId = videoIdMatch[1];
+					}
 				}
 				youtubeSettings = {
 						container: container,


### PR DESCRIPTION
The current way doesn't support URLs which have more than one query argument like `https://www.youtube.com/watch?v=xxxxxxx&foo=bar`.

WordPress ticket: https://core.trac.wordpress.org/ticket/37363