### PR TITLE
Fix wrong parameter send to "player.options.defaultSeekForwardInterva…

### DIFF
--- a/src/js/mep-feature-progress.js
+++ b/src/js/mep-feature-progress.js
@@ -125,8 +125,8 @@
 				var keyCode = e.keyCode,
 					duration = media.duration,
 					seekTime = media.currentTime,
-					seekForward  = player.options.defaultSeekForwardInterval(duration),
-					seekBackward = player.options.defaultSeekBackwardInterval(duration);
+					seekForward  = player.options.defaultSeekForwardInterval(media),
+					seekBackward = player.options.defaultSeekBackwardInterval(media);
 
 				switch (keyCode) {
 				case 37: // left


### PR DESCRIPTION
 `player.options.defaultSeekForwardInterval()` and  `player.options.defaultSeekBackwardInterval()` signature changed before. So update the parameter where still using the old signature.