### PR TITLE
Hide controls when video is paused

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -74,7 +74,7 @@
 		// Display the video control
 		hideVideoControlsOnLoad: false,
 		// Hide control bar when video is paused
-		hideVideoControlOnPause: false,
+		hideVideoControlOnPause: true,
 		// Enable click video element to toggle play/pause
 		clickToPlayPause: true,
 		// force iPad's native controls
@@ -469,7 +469,7 @@
 			doAnimation = typeof doAnimation == 'undefined' || doAnimation;
 
 			if (!t.controlsAreVisible || t.options.alwaysShowControls || t.keyboardAction ||
-				(t.options.hideVideoControlOnPause && t.media.paused))
+				(!t.options.hideVideoControlOnPause && t.media.paused))
 				return;
 
 			if (doAnimation) {

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -74,7 +74,7 @@
 		// Display the video control
 		hideVideoControlsOnLoad: false,
 		// Hide control bar when video is paused
-		hideVideoControlOnPause: true,
+		hideVideoControlOnPause: false,
 		// Enable click video element to toggle play/pause
 		clickToPlayPause: true,
 		// force iPad's native controls

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -73,8 +73,6 @@
 		alwaysShowControls: false,
 		// Display the video control
 		hideVideoControlsOnLoad: false,
-		// Hide control bar when video is paused
-		hideVideoControlOnPause: false,
 		// Enable click video element to toggle play/pause
 		clickToPlayPause: true,
 		// force iPad's native controls
@@ -468,8 +466,7 @@
 
 			doAnimation = typeof doAnimation == 'undefined' || doAnimation;
 
-			if (!t.controlsAreVisible || t.options.alwaysShowControls || t.keyboardAction ||
-				(!t.options.hideVideoControlOnPause && t.media.paused))
+			if (!t.controlsAreVisible || t.options.alwaysShowControls || t.keyboardAction || t.media.paused)
 				return;
 
 			if (doAnimation) {

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -73,6 +73,8 @@
 		alwaysShowControls: false,
 		// Display the video control
 		hideVideoControlsOnLoad: false,
+		// Hide control bar when video is paused
+		hideVideoControlOnPause: false,
 		// Enable click video element to toggle play/pause
 		clickToPlayPause: true,
 		// force iPad's native controls
@@ -466,7 +468,8 @@
 
 			doAnimation = typeof doAnimation == 'undefined' || doAnimation;
 
-			if (!t.controlsAreVisible || t.options.alwaysShowControls || t.keyboardAction)
+			if (!t.controlsAreVisible || t.options.alwaysShowControls || t.keyboardAction ||
+				(t.options.hideVideoControlOnPause && t.media.paused))
 				return;
 
 			if (doAnimation) {

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -466,7 +466,7 @@
 
 			doAnimation = typeof doAnimation == 'undefined' || doAnimation;
 
-			if (!t.controlsAreVisible || t.options.alwaysShowControls || t.keyboardAction || t.media.paused)
+			if (!t.controlsAreVisible || t.options.alwaysShowControls || t.keyboardAction || t.media.paused || media.ended)
 				return;
 
 			if (doAnimation) {


### PR DESCRIPTION
Currently, some of the most popular players allow the video controls to remain visible when the video is paused. So this feature allows to configure that behavior