### PR TITLE
detect fullscreen mode when media can play

### DIFF
--- a/src/js/mep-feature-fullscreen.js
+++ b/src/js/mep-feature-fullscreen.js
@@ -31,7 +31,7 @@
 			player.isInIframe = (window.location != window.parent.location);	
 		
 			// detect on start
-			media.addEventListener('play', function() { player.detectFullscreenMode(); });
+			media.addEventListener('canplay', function() { player.detectFullscreenMode(); });
 				
 			// build button
 			var t = this,


### PR DESCRIPTION
Fixes an issue where user tries to go to fullscreen before playing video
first. When in an iframe, this results in the video not using native fullscreen.