### PR TITLE
send focus to correct control based on location

### DIFF
--- a/src/js/me-utility.js
+++ b/src/js/me-utility.js
@@ -274,5 +274,19 @@ mejs.Utility = {
 			timeout = setTimeout(later, wait);
 			if (callNow) func.apply(context, args);
 		};
+	},
+
+	/**
+	* Returns true if targetNode appears after sourceNode in the dom.
+	* @param {HTMLElement} sourceNode - the source node for comparison
+	* @param {HTMLElement} targetNode - the node to compare against sourceNode
+	*/
+	isNodeAfter: function(sourceNode, targetNode) {
+		return !!(
+			sourceNode &&
+			targetNode &&
+			typeof sourceNode.compareDocumentPosition === 'function' &&
+			sourceNode.compareDocumentPosition(targetNode) & Node.DOCUMENT_POSITION_PRECEDING
+		);
 	}
 };

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1,17 +1,3 @@
-/**
- * Returns true if targetNode appears after sourceNode in the dom.
- * @param {HTMLElement} sourceNode - the source node for comparison
- * @param {HTMLElement} targetNode - the node to compare against sourceNode
- */
-function isAfter(sourceNode, targetNode) {
-	return !!(
-		sourceNode &&
-		targetNode &&
-		typeof sourceNode.compareDocumentPosition === 'function' &&
-		sourceNode.compareDocumentPosition(targetNode) & Node.DOCUMENT_POSITION_PRECEDING
-	);
-}
-
 (function ($) {
 
 	// default player values
@@ -357,7 +343,7 @@ function isAfter(sourceNode, targetNode) {
 								// else send focus to last control button.
 								var btnSelector = '.mejs-playpause-button > button';
 
-								if (isAfter(e.relatedTarget, t.container[0])) {
+								if (mejs.Utility.isNodeAfter(e.relatedTarget, t.container[0])) {
 									btnSelector = '.mejs-controls .mejs-button:last-child > button';
 								}
 

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -4,11 +4,8 @@
  * @param {HTMLElement} targetNode - the node to compare against sourceNode
  */
 function isAfter(sourceNode, targetNode) {
-	if (!sourceNode) {
-		throw new TypeError('Source node is missing or undefined');
-	}
-
 	return !!(
+		sourceNode &&
 		targetNode &&
 		sourceNode.compareDocumentPosition(targetNode) & Node.DOCUMENT_POSITION_PRECEDING
 	);

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1,3 +1,19 @@
+/**
+ * Returns true if targetNode appears after sourceNode in the dom.
+ * @param {HTMLElement} sourceNode - the source node for comparison
+ * @param {HTMLElement} targetNode - the node to compare against sourceNode
+ */
+function isAfter(sourceNode, targetNode) {
+	if (!sourceNode) {
+		throw new TypeError('Source node is missing or undefined');
+	}
+
+	return !!(
+		targetNode &&
+		sourceNode.compareDocumentPosition(targetNode) & Node.DOCUMENT_POSITION_PRECEDING
+	);
+}
+
 (function ($) {
 
 	// default player values
@@ -339,8 +355,16 @@
 							// if user clicks on the Play/Pause button in the control bar once it attempts
 							// to hide it
 							if (!t.hasMsNativeFullScreen) {
-								var playButton = t.container.find('.mejs-playpause-button > button');
-								playButton.focus();
+								// If e.relatedTarget appears before container, send focus to play button,
+								// else send focus to last control button.
+								var btnSelector = '.mejs-playpause-button > button';
+
+								if (isAfter(e.relatedTarget, t.container[0])) {
+									btnSelector = '.mejs-controls .mejs-button:last-child > button';
+								}
+
+								var button = t.container.find(btnSelector);
+								button.focus();
 							}
 						}
 					});

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -7,6 +7,7 @@ function isAfter(sourceNode, targetNode) {
 	return !!(
 		sourceNode &&
 		targetNode &&
+		typeof sourceNode.compareDocumentPosition === 'function' &&
 		sourceNode.compareDocumentPosition(targetNode) & Node.DOCUMENT_POSITION_PRECEDING
 	);
 }


### PR DESCRIPTION
This changes increases parity with the youtube player as it relates to focus management. Previously, if focused on an element later in the dom, the player would send focus to the play button instead of the last focusable control.