### PR TITLE
Fix control icons with CSS in different path

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -67,7 +67,7 @@ If you wish to install the sources in different directories (i.e., all Javascrip
 }
 
 .mejs-controls .mejs-button button {
-    background: transparent url("/path/to/controls.svg") no-repeat;
+    background-image: url("/path/to/controls.svg");
 }
 </style>
 ```


### PR DESCRIPTION
When setting `background` instead of `background-image`, it seems as if the `background-position` property gets also overwritten, which results in all icons showing the first one (play) instead of the icon at their actual position in the sprite.