### PR TITLE
Firefox event bubbling fix

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -108,12 +108,15 @@
 								32, // SPACE
 								179 // GOOGLE play/pause button
 								 ],
-						action: function(player, media) {
+						action: function(player, media, key, event) {
+
+							if (!mejs.MediaFeatures.isFirefox) {
 								if (media.paused || media.ended) {
-										media.play();
+									media.play();
 								} else {
-										media.pause();
+									media.pause();
 								}
+							}
 						}
 				},
 				{


### PR DESCRIPTION
This PR solves an issue related to the space bar triggering a click event as well only on Firefox; issue described in #1508