### PR TITLE
Fix compilation error when using yuicompressor

### DIFF
--- a/src/js/me-i18n.js
+++ b/src/js/me-i18n.js
@@ -114,8 +114,8 @@
         }
 
         // Fallback to default language if requested uid is not translated
-        if (!str && i18n.locale.strings && i18n.locale.strings[i18n.default]) {
-            str = i18n.locale.strings[i18n.default][uid];
+        if (!str && i18n.locale.strings && i18n.locale.strings[i18n["default"]]) {
+            str = i18n.locale.strings[i18n["default"]][uid];
         }
 
         // As a last resort, use the requested uid, to mimic original behavior of i18n utils (in which uid was the english text)


### PR DESCRIPTION
"default" is a javascript reservedd keyword and should not be used as variable name when using dot notation.

--> Use backets notation to retrieve default language