### PR TITLE
Unify language files

### DIFF
--- a/src/me-i18n-locale-cs.js
+++ b/src/me-i18n-locale-cs.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Czech
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.cs === undefined) {
+        exports.cs = {
+            "mejs.plural-form": 8,
+
+            // me-shim
+            "mejs.download-file": "Stáhnout soubor",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Vypnout režim celá obrazovka",
+            "mejs.fullscreen-on": "Na celou obrazovku",
+            "mejs.download-video": "Stáhnout video",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Celá obrazovka",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "Přehrát",
+            "mejs.pause": "Pozastavit",
+
+            // mep-feature-postroll
+            "mejs.close": "Zavřít",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Posuvný běžec nastavení času",
+            "mejs.time-help-text": "Použijte tlačítka se šipkami doleva / doprava pro posun o jednu vteřinu, tlačítka se šipkami nahoru / dolů pro posun o deset vteřin.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "Zpět o %1 vteřin",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Titulky",
+            "mejs.none": "Žádný",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Vypnout/zapnout zvuk",
+            "mejs.volume-help-text": "Použijte tlačítka se šipkami nahoru / dolů pro zesílení nebo zeslabení hlasitosti.",
+            "mejs.unmute": "Zapnout zvuk",
+            "mejs.mute": "Vypnout zvuk",
+            "mejs.volume-slider": "Posuvný běžec nastavení hlasitosti",
+
+            // mep-player
+            "mejs.video-player": "Přehrávač videa",
+            "mejs.audio-player": "Přehrávač hudby",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-de.js
+++ b/src/me-i18n-locale-de.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * German
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.de === undefined) {
+        exports.de = {
+            "mejs.plural-form": 1,
+
+            // me-shim
+            "mejs.download-file": "Datei herunterladen",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Vollbildmodus beenden",
+            "mejs.fullscreen-on": "Vollbild",
+            "mejs.download-video": "Video herunterladen",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Vollbild",
+
+            // mep-feature-jumpforward
+            "mejs.time-jump-forward": ["1 Sekunde vorspulen", "%1 Sekunden vorspulen"],
+
+            // mep-feature-playpause
+            "mejs.play": "Abspielen",
+            "mejs.pause": "Pause",
+
+            // mep-feature-postroll
+            "mejs.close": "Schließen",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Zeitschieberegler",
+            "mejs.time-help-text": "Verwende die Pfeiltaste nach links/rechts, um eine Sekunde zu spulen, hoch/runter um zehn Sekunden zu spulen.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": ["1 Sekunde zurückspulen", "%1 Sekunden zurückspulen"],
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Überschriften/Untertitel",
+            "mejs.none": "Keine",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Stummschaltung umschalten",
+            "mejs.volume-help-text": "Verwende die Pfeiltaste nach oben/nach unten um die Lautstärke zu erhöhen oder zu verringern.",
+            "mejs.unmute": "Stummschaltung aufheben",
+            "mejs.mute": "Stummschalten",
+            "mejs.volume-slider": "Lautstärkeregler",
+
+            // mep-player
+            "mejs.video-player": "Video-Player",
+            "mejs.audio-player": "Audio-Player",
+
+            // mep-feature-ads
+            "mejs.ad-skip": "Werbung überspringen",
+            "mejs.ad-skip-info": ["Überspringen in 1 Sekunde", "Überspringen in %1 Sekunden"],
+
+            // mep-feature-sourcechooser
+            "mejs.source-chooser": "Quellenauswahl"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-en.js
+++ b/src/me-i18n-locale-en.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * English; This can serve as a template for other languages to translate
+ *
+ * @author
+ *   TBD
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.en === undefined) {
+        exports.en = {
+            "mejs.plural-form": 1,
+
+            // me-shim
+            "mejs.download-file": "Download File",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Turn off Fullscreen",
+            "mejs.fullscreen-on": "Go Fullscreen",
+            "mejs.download-video": "Download Video",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Fullscreen",
+
+            // mep-feature-jumpforward
+            "mejs.time-jump-forward": ["Jump forward 1 second", "Jump forward %1 seconds"],
+
+            // mep-feature-playpause
+            "mejs.play": "Play",
+            "mejs.pause": "Pause",
+
+            // mep-feature-postroll
+            "mejs.close": "Close",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Time Slider",
+            "mejs.time-help-text": "Use Left/Right Arrow keys to advance one second, Up/Down arrows to advance ten seconds.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": ["Skip back 1 second", "Skip back %1 seconds"],
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Captions/Subtitles",
+            "mejs.none": "None",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Mute Toggle",
+            "mejs.volume-help-text": "Use Up/Down Arrow keys to increase or decrease volume.",
+            "mejs.unmute": "Unmute",
+            "mejs.mute": "Mute",
+            "mejs.volume-slider": "Volume Slider",
+
+            // mep-player
+            "mejs.video-player": "Video Player",
+            "mejs.audio-player": "Audio Player",
+
+            // mep-feature-ads
+            "mejs.ad-skip": "Skip ad",
+            "mejs.ad-skip-info": ["Skip in 1 second", "Skip in %1 seconds"],
+
+            // mep-feature-sourcechooser
+            "mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-es.js
+++ b/src/me-i18n-locale-es.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Spanish
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.es === undefined) {
+        exports.es = {
+            "mejs.plural-form": 1,
+
+            // me-shim
+            "mejs.download-file": "Descargar archivo",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Desconectar pantalla completa",
+            "mejs.fullscreen-on": "Ir a pantalla completa",
+            "mejs.download-video": "Descargar vídeo",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Pantalla completa",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "Reproducción",
+            "mejs.pause": "Pausa",
+
+            // mep-feature-postroll
+            "mejs.close": "Cerrar",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Control deslizante de tiempo",
+            "mejs.time-help-text": "Use las flechas Izquierda/Derecha para avanzar un segundo y las flechas Arriba/Abajo para avanzar diez segundos.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": ["Rebobinar 1 segundo", "Rebobinar %1 segundos"],
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Leyendas/Subtítulos",
+            "mejs.none": "Ninguno",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Alternar silencio",
+            "mejs.volume-help-text": "Use las flechas Arriba/Abajo para subir o bajar el volumen.",
+            "mejs.unmute": "Reactivar silencio",
+            "mejs.mute": "Silencio",
+            "mejs.volume-slider": "Control deslizante de volumen",
+
+            // mep-player
+            "mejs.video-player": "Reproductor de video",
+            "mejs.audio-player": "Reproductor de audio",
+
+            // mep-feature-ads
+            "mejs.ad-skip": "Saltar publicidad",
+            "mejs.ad-skip-info": ["Saltar 1 segundo", "Saltar %1 segundos"],
+
+            // mep-feature-sourcechooser
+            "mejs.source-chooser": "Selector de media"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-fr.js
+++ b/src/me-i18n-locale-fr.js
@@ -1,0 +1,75 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * French
+ *
+ * @author
+ *   Luc Poupard (Twitter: @klohFR)
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.fr === undefined) {
+        exports.fr = {
+            "mejs.plural-form": 2,
+
+            // me-shim
+            "mejs.download-file": "Télécharger le fichier",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Quitter le mode plein écran",
+            "mejs.fullscreen-on": "Afficher en plein écran",
+            "mejs.download-video": "Télécharger la vidéo",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Plein écran",
+
+            // mep-feature-jumpforward
+            "mejs.time-jump-forward": "Avancer de %1 secondes",
+
+            // mep-feature-playpause
+            "mejs.play": "Lecture",
+            "mejs.pause": "Pause",
+
+            // mep-feature-postroll
+            "mejs.close": "Fermer",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Curseur temporel",
+            "mejs.time-help-text": "Utilisez les flèches Gauche/Droite du clavier pour avancer d'une seconde, les flèches Haut/Bas pour avancer de 10 secondes.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "Reculer de %1 secondes",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Sous-titres",
+            "mejs.none": "Aucun",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Activer/désactiver le son",
+            "mejs.volume-help-text": "Utilisez les flèches Haut/Bas du clavier pour augmenter ou diminuer le volume.",
+            "mejs.unmute": "Activer le son",
+            "mejs.mute": "Désactiver le son",
+            "mejs.volume-slider": "Volume",
+
+            // mep-player
+            "mejs.video-player": "Lecteur Vidéo",
+            "mejs.audio-player": "Lecteur Audio",
+
+            // mep-feature-ads
+            "mejs.ad-skip": "Passer la publicité",
+            "mejs.ad-skip-info": "Passer la publicité dans %1 secondes",
+
+            // mep-feature-sourcechooser
+            "mejs.source-chooser": "Sélecteur de média"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-hu.js
+++ b/src/me-i18n-locale-hu.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Hungarian
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.hu === undefined) {
+        exports.hu = {
+            "mejs.plural-form": 1,
+
+            // me-shim
+            "mejs.download-file": "Fájl letöltése",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Teljes képernyő kikapcsolása",
+            "mejs.fullscreen-on": "Átlépés teljes képernyős módra",
+            "mejs.download-video": "Videó letöltése",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Teljes képernyő",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "Lejátszás",
+            "mejs.pause": "Szünet",
+
+            // mep-feature-postroll
+            "mejs.close": "Bezárás",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Idő csúszka",
+            "mejs.time-help-text": "Használja a Bal/Jobb nyíl gombokat az egy másodperces léptetéshez, a Fel/Le nyíl gombokat a tíz másodperces léptetéshez.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "Ugrás vissza %1 másodperccel",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Képaláírás/Feliratok",
+            "mejs.none": "Nincs",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Némítás kapcsolója",
+            "mejs.volume-help-text": "Használja a Fel/Le nyíl gombokat a hangerő növeléséhez vagy csökkentéséhez.",
+            "mejs.unmute": "Némítás feloldása",
+            "mejs.mute": "Némítás",
+            "mejs.volume-slider": "Hangerőcsúszka",
+
+            // mep-player
+            "mejs.video-player": "Videolejátszó",
+            "mejs.audio-player": "Audiolejátszó",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-it.js
+++ b/src/me-i18n-locale-it.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Italian
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha "SoftCreatR" Greuel
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.it === undefined) {
+        exports.it = {
+            "mejs.plural-form": 1,
+
+            // me-shim
+            "mejs.download-file": "Scaricare il file",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Disattivare lo schermo intero",
+            "mejs.fullscreen-on": "Attivare lo schermo intero",
+            "mejs.download-video": "Scaricare il video",
+
+             // mep-feature-fullscreen
+            "mejs.fullscreen": "Schermo intero",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "Eseguire",
+            "mejs.pause": "Pausa",
+
+            // mep-feature-postroll
+            "mejs.close": "Chiudere",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Barra di scorrimento",
+            "mejs.time-help-text": "Utilizzare i tasti Freccia sinistra/Freccia destra per avanzare di un secondo, Freccia Su/Giù per avanzare dieci secondi.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "Riavvolgere %1 secondi",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Acquisizioni/sottotitoli",
+            "mejs.none": "Nessuno",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Toggle muto",
+            "mejs.volume-help-text": "Utilizzare i tasti Freccia Su/Giù per aumentare o diminuire il volume.",
+            "mejs.unmute": "Disattivare muto",
+            "mejs.mute": "Muto",
+            "mejs.volume-slider": "Barra del volume",
+
+            // mep-player
+            "mejs.video-player": "Lettore Video",
+            "mejs.audio-player": "Lettore Audio",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-ja.js
+++ b/src/me-i18n-locale-ja.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Japanese
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha "SoftCreatR" Greuel
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.ja === undefined) {
+        exports.ja = {
+            "mejs.plural-form": 0,
+
+            // me-shim
+            "mejs.download-file": "ファイルをダウンロードする",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "全画面をオフにする",
+            "mejs.fullscreen-on": "全画面にする",
+            "mejs.download-video": "動画をダウンロードする",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "全画面",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "再生",
+            "mejs.pause": "一時停止",
+
+            // mep-feature-postroll
+            "mejs.close": "閉じる",
+
+            // mep-feature-progress
+            "mejs.time-slider": "タイムスライダー",
+            "mejs.time-help-text": "1秒進めるには左/右矢印をキーを、10秒進めるには上/下矢印を使います。",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "%1秒スキップバックする",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "キャプション/字幕",
+            "mejs.none": "なし",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "ミュートトグル",
+            "mejs.volume-help-text": "音量を上げたり下げたりするには、上/下矢印を使います。",
+            "mejs.unmute": "ミュートを解除",
+            "mejs.mute": "ミュート",
+            "mejs.volume-slider": "音量スライダー",
+
+            // mep-player
+            "mejs.video-player": "ビデオプレーヤー",
+            "mejs.audio-player": "オーディオプレーヤー",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-ko.js
+++ b/src/me-i18n-locale-ko.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Korean
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha "SoftCreatR" Greuel
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.ko === undefined) {
+        exports.ko = {
+            "mejs.plural-form": 0,
+
+            // me-shim
+            "mejs.download-file": "파일 다운로드",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "전체화면 해제",
+            "mejs.fullscreen-on": "전체화면 가기",
+            "mejs.download-video": "비디오 다운로드",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "전체화면",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "작동",
+            "mejs.pause": "정지",
+
+            // mep-feature-postroll
+            "mejs.close": "종료",
+
+            // mep-feature-progress
+            "mejs.time-slider": "시간 슬라이더",
+            "mejs.time-help-text": "1초 전진하려면 좌/우측 화살표를 사용하시고 10초 전진하려면 위/아래 화살표를 사용하세요.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "1초 % 를 뒤로 건너뛰세요",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "캡션/자막",
+            "mejs.none": "없음",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "음소거 전환",
+            "mejs.volume-help-text": "볼륨을 높이거나 낮추려면 위/아래 화살표를 이용하세요.",
+            "mejs.unmute": "음소거 해제",
+            "mejs.mute": "말 없는",
+            "mejs.volume-slider": "볼륨 슬라이더",
+
+            // mep-player
+            "mejs.video-player": "비디오 플레이어",
+            "mejs.audio-player": "오디오 플레이어",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-nl.js
+++ b/src/me-i18n-locale-nl.js
@@ -1,0 +1,75 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Dutch
+ *
+ * @author
+ *   Leonard de Ruijter, Twitter: @LeonarddR
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha "SoftCreatR" Greuel
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.nl === undefined) {
+        exports.nl = {
+            "mejs.plural-form": 1,
+
+            // me-shim
+            "mejs.download-file": "Bestand downloaden",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Volledig scherm uitschakelen",
+            "mejs.fullscreen-on": "Volledig scherm",
+            "mejs.download-video": "Video downloaden",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Volledig scherm",
+
+            // mep-feature-jumpforward
+            "mejs.time-jump-forward": "%1 seconden vooruit springen",
+
+            // mep-feature-playpause
+            "mejs.play": "Afspelen",
+            "mejs.pause": "Pauzeren",
+
+            // mep-feature-postroll
+            "mejs.close": "Sluiten",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Tijd schuifbalk",
+            "mejs.time-help-text": "Gebruik pijl naar links/rechts om per seconde te springen, pijl omhoog/omlaag om per tien seconden te springen.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "%1 seconden terug springen",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Bijschriften/ondertiteling",
+            "mejs.none": "Geen",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Dempen schakelen",
+            "mejs.volume-help-text": "Gebruik pijl omhoog/omlaag om het volume te verhogen/verlagen.",
+            "mejs.unmute": "Dempen opheffen",
+            "mejs.mute": "Dempen",
+            "mejs.volume-slider": "Volume schuifbalk",
+
+            // mep-player
+            "mejs.video-player": "Videospeler",
+            "mejs.audio-player": "Audiospeler",
+
+            // mep-feature-ads
+            "mejs.ad-skip": "Ad overslaan",
+            "mejs.ad-skip-info": "Overslaan in %1 seconden",
+
+            // mep-feature-sourcechooser
+            "mejs.source-chooser": "Bronkeuze"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-pl.js
+++ b/src/me-i18n-locale-pl.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Polish
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.pl === undefined) {
+        exports.pl = {
+            "mejs.plural-form": 9,
+
+            // me-shim
+            "mejs.download-file": "Pobierz plik",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Wyłącz pełny ekran",
+            "mejs.fullscreen-on": "Przejdź na pełny ekran",
+            "mejs.download-video": "Pobierz wideo",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Pełny ekran",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "Odtwarzaj",
+            "mejs.pause": "Wstrzymaj",
+
+            // mep-feature-postroll
+            "mejs.close": "Zamknij",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Suwak czasu",
+            "mejs.time-help-text": "Strzałki w lewo/w prawo powodują przewijanie o sekundę, strzałki w górę/w dół o dziesięć sekund.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "Cofnij o %1 sek.",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Podpisy/napisy",
+            "mejs.none": "Brak",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Przełączanie wyciszania",
+            "mejs.volume-help-text": "Aby zwiększyć lub zmniejszyć głośność, użyj strzałek w górę/w dół.",
+            "mejs.unmute": "Wyłącz wyciszenie",
+            "mejs.mute": "Wycisz",
+            "mejs.volume-slider": "Suwak głośności",
+
+            // mep-player
+            "mejs.video-player": "Odtwarzacz wideo",
+            "mejs.audio-player": "Odtwarzacz audio",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-pt-br.js
+++ b/src/me-i18n-locale-pt-br.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Brazilian (Portuguese)
+ *
+ * @author
+ *   Armando Meziat (Twitter: @odnamrataizem)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports["pt-BR"] === undefined) {
+        exports["pt-BR"] = {
+            "mejs.plural-form": 2,
+
+            // me-shim
+            "mejs.download-file": "Baixar arquivo",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Sair da tela inteira",
+            "mejs.fullscreen-on": "Ir para tela inteira",
+            "mejs.download-video": "Baixar vídeo",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Tela inteira",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            //"mejs.play": "Play",
+            //"mejs.pause": "Pause",
+
+            // mep-feature-postroll
+            "mejs.close": "Fechar",
+
+            // mep-feature-progress
+            //"mejs.time-slider": "Time Slider",
+            //"mejs.time-help-text": "Use Left/Right Arrow keys to advance one second, Up/Down arrows to advance ten seconds.",
+
+            // mep-feature-skipback
+            //"mejs.time-skip-back": "Skip back %1 second(s)",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Legendas",
+            "mejs.none": "Sem legendas",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Alternar silêncio",
+            //"mejs.volume-help-text": "Use Up/Down Arrow keys to increase or decrease volume.",
+            "mejs.unmute": "Tirar silêncio",
+            "mejs.mute": "Silenciar",
+            //"mejs.volume-slider": "Volume Slider",
+
+            // mep-player
+            //"mejs.video-player": "Video Player",
+            //"mejs.audio-player": "Audio Player",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-pt.js
+++ b/src/me-i18n-locale-pt.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Portuguese
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.pt === undefined) {
+        exports.pt = {
+            "mejs.plural-form": 1,
+
+            // me-shim
+            "mejs.download-file": "Descarregar o ficheiro",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Desligar ecrã completo",
+            "mejs.fullscreen-on": "Ir para ecrã completo",
+            "mejs.download-video": "Descarregar o vídeo",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Ecrã completo",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "Reprodução",
+            "mejs.pause": "Pausa",
+
+            // mep-feature-postroll
+            "mejs.close": "Fechar",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Deslizador do tempo",
+            "mejs.time-help-text": "Use as teclas das setas para a esquerda/direita para avançar um segundo, e as setas para cima/baixo para avançar dez segundos.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "Retroceder %1 segundos",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Legendas",
+            "mejs.none": "Nenhum",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Alternar silêncio",
+            "mejs.volume-help-text": "Use as teclas das setas para cima/baixo para aumentar ou diminuir o volume.",
+            "mejs.unmute": "Voltar ao som",
+            "mejs.mute": "Silêncio",
+            "mejs.volume-slider": "Deslizador do volume",
+
+            // mep-player
+            "mejs.video-player": "Leitor de vídeo",
+            "mejs.audio-player": "Leitor de áudio",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-ro.js
+++ b/src/me-i18n-locale-ro.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Romanian
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.ro === undefined) {
+        exports.ro = {
+            "mejs.plural-form": 5,
+
+            // me-shim
+            "mejs.download-file": "Descarcă fişierul",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Opreşte ecranul complet",
+            "mejs.fullscreen-on": "Treci la ecran complet",
+            "mejs.download-video": "Descarcă fişierul video",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Ecran complet",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "Redare",
+            "mejs.pause": "Pauză",
+
+            // mep-feature-postroll
+            "mejs.close": "Închide",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Cursor timp",
+            "mejs.time-help-text": "Utilizează tastele săgeată Stânga/Dreapta pentru a avansa o secundă şi săgeţile Sus/Jos pentru a avansa zece secunde.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "Sari înapoi %1 secunde",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Legende/Subtitrări",
+            "mejs.none": "Niciunul",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Comutare dezactivare sunet",
+            "mejs.volume-help-text": "Utilizează tastele de săgeată Sus/Jos pentru a creşte/micşora volumul",
+            "mejs.unmute": "Cu sunet",
+            "mejs.mute": "Fără sunet",
+            "mejs.volume-slider": "Cursor volum",
+
+            // mep-player
+            "mejs.video-player": "Player video",
+            "mejs.audio-player": "Player audio",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-ru.js
+++ b/src/me-i18n-locale-ru.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Russian
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.ru === undefined) {
+        exports.ru = {
+            "mejs.plural-form": 7,
+
+            // me-shim
+            "mejs.download-file": "Скачать файл",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Выключить широкий экран",
+            "mejs.fullscreen-on": "Перейти к широкому экрану",
+            "mejs.download-video": "Скачать видео",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Широкий экран",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "Воспроизвести",
+            "mejs.pause": "Пауза",
+
+            // mep-feature-postroll
+            "mejs.close": "Закрыть",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Слайдер времени",
+            "mejs.time-help-text": "Используйте Левую/Правую клавиши со стрелками, чтобы продвинуться на одну секунду, клавиши со стрелками Вверх/Вниз, чтобы продвинуться на десять секунд.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "Пропустить назад %1 секунд",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Титры/Субтитры",
+            "mejs.none": "Нет",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Без звука",
+            "mejs.volume-help-text": "Используйте клавиши со стрелками Вверх/Вниз, чтобы увеличить или уменьшить громкость.",
+            "mejs.unmute": "Отменить выключение звука",
+            "mejs.mute": "Отключить звук",
+            "mejs.volume-slider": "Слайдер громкости",
+
+            // mep-player
+            "mejs.video-player": "Видеоплеер",
+            "mejs.audio-player": "Аудиоплеер",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-sk.js
+++ b/src/me-i18n-locale-sk.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Slovak
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.sk === undefined) {
+        exports.sk = {
+            "mejs.plural-form": 8,
+
+            // me-shim
+            "mejs.download-file": "Prevziať súbor",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "Vypnúť celú obrazovku",
+            "mejs.fullscreen-on": "Prejsť na celú obrazovku",
+            "mejs.download-video": "Prevziať video",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "Celá obrazovka",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "Prehrať",
+            "mejs.pause": "Pozastaviť",
+
+            // mep-feature-postroll
+            "mejs.close": "Zavrieť",
+
+            // mep-feature-progress
+            "mejs.time-slider": "Posúvač času",
+            "mejs.time-help-text": "Klávesmi so šípkou doľava/doprava posuniete o jednu sekundu, šípkami nahor/ nadol posuniete o desať sekúnd.",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "Preskočiť dozadu o %1 s.",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "Skryté titulky/Titulky",
+            "mejs.none": "Žiadne",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "Prepínač stlmenia",
+            "mejs.volume-help-text": "Klávesmi so šípkou nahor/nadol zvýšite alebo znížite hlasitosť.",
+            "mejs.unmute": "Zrušiť stlmenie",
+            "mejs.mute": "Stlmiť",
+            "mejs.volume-slider": "Posúvač hlasitosti",
+
+            // mep-player
+            "mejs.video-player": "Prehrávač videa",
+            "mejs.audio-player": "Prehrávač zvuku",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-zh-cn.js
+++ b/src/me-i18n-locale-zh-cn.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Chinese (Simplified)
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports["zh-CN"] === undefined) {
+        exports["zh-CN"] = {
+            "mejs.plural-form": 0,
+
+            // me-shim
+            "mejs.download-file": "下载文件",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "关闭全屏",
+            "mejs.fullscreen-on": "转向全屏",
+            "mejs.download-video": "下载视频",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "全屏",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "播放",
+            "mejs.pause": "暂停",
+
+            // mep-feature-postroll
+            "mejs.close": "关闭",
+
+            // mep-feature-progress
+            "mejs.time-slider": "时间滑动棒",
+            "mejs.time-help-text": "使用作/右箭头快进1秒，使用上/下箭头快进10秒。",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "后退%1秒",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "字幕/标题",
+            "mejs.none": "无",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "静音切换",
+            "mejs.volume-help-text": "使用上/下箭头提高或降低音量。",
+            "mejs.unmute": "取消静音",
+            "mejs.mute": "静音",
+            "mejs.volume-slider": "音量选择键",
+
+            // mep-player
+            "mejs.video-player": "视频播放器",
+            "mejs.audio-player": "音频播放器",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));

--- a/src/me-i18n-locale-zh.js
+++ b/src/me-i18n-locale-zh.js
@@ -1,0 +1,74 @@
+/*!
+ * This is a i18n.locale language object.
+ *
+ * Chinese (Traditional)
+ *
+ * @author
+ *   Jalios (Twitter: @Jalios)
+ *   Sascha Greuel (Twitter: @SoftCreatR)
+ *
+ * @see
+ *   me-i18n.js
+ *
+ * @params
+ *  - exports - CommonJS, window ..
+ */
+(function (exports) {
+    "use strict";
+
+    if (exports.zh === undefined) {
+        exports.zh = {
+            "mejs.plural-form": 0,
+
+            // me-shim
+            "mejs.download-file": "下載文件",
+
+            // mep-feature-contextmenu
+            "mejs.fullscreen-off": "關閉全屏",
+            "mejs.fullscreen-on": "轉向全屏",
+            "mejs.download-video": "下載視頻",
+
+            // mep-feature-fullscreen
+            "mejs.fullscreen": "全屏",
+
+            // mep-feature-jumpforward
+            //"mejs.time-jump-forward": "Jump forward %1 second(s)",
+
+            // mep-feature-playpause
+            "mejs.play": "播放",
+            "mejs.pause": "暫停",
+
+            // mep-feature-postroll
+            "mejs.close": "關閉",
+
+            // mep-feature-progress
+            "mejs.time-slider": "時間滑動棒",
+            "mejs.time-help-text": "使用左/右箭頭快進1秒，上/下箭頭快進10秒。",
+
+            // mep-feature-skipback
+            "mejs.time-skip-back": "跳躍式迴繞%1秒",
+
+            // mep-feature-tracks
+            "mejs.captions-subtitles": "字幕/標題",
+            "mejs.none": "沒有",
+
+            // mep-feature-volume
+            "mejs.mute-toggle": "靜音切換",
+            "mejs.volume-help-text": "使用上/下箭頭提高或降低音量。",
+            "mejs.unmute": "取消靜音",
+            "mejs.mute": "靜音",
+            "mejs.volume-slider": "音量控制鍵",
+
+            // mep-player
+            "mejs.video-player": "視頻播放器",
+            "mejs.audio-player": "音頻播放器",
+
+            // mep-feature-ads
+            //"mejs.ad-skip": "Skip ad",
+            //"mejs.ad-skip-info": "Skip in %1 second(s)",
+
+            // mep-feature-sourcechooser
+            //"mejs.source-chooser": "Source Chooser"
+        };
+    }
+}(mejs.i18n.locale.strings));


### PR DESCRIPTION
Currently, most language files are not based on any "standard template". To make translations easier, they should.

They should also contain all phrases, which are used by Mejs, even if these phrases havent been translated, yet. So translators can see, which phrases need translation.

Furthermore, the code style needs an update, according to JSLint.