### PR TITLE
Add blur handler to hide volume slider

### DIFF
--- a/src/js/mep-feature-volume.js
+++ b/src/js/mep-feature-volume.js
@@ -232,8 +232,10 @@
 			});
 
 			//Keyboard input
-			mute.find('button').bind('focus', function () {
+			mute.find('button').on('focus', function () {
 				volumeSlider.show();
+			}).on('blur', function () {
+				volumeSlider.hide();
 			});
 
 			// listen for volume change events from other sources


### PR DESCRIPTION
When "alwaysShowControls" is set to true, using the keyboard to focus on the mute button causes the volume slider to appear, but leaving the control fails to hide the volume slider again. This modification updates the event handler to use the `.on()` method (as `.bind()` is deprecated in jQuery) and adds a handler for the "blur" event that explicitly hides the control.