### PR TITLE
Fix removal of mediaelement when native controls are used

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1459,8 +1459,6 @@
 		remove: function() {
 			var t = this, featureIndex, feature;
 
-			t.container.prev('.mejs-offscreen').remove();
-
 			// invoke features cleanup
 			for (featureIndex in t.options.features) {
 				feature = t.options.features[featureIndex];
@@ -1496,6 +1494,7 @@
 			delete mejs.players[t.id];
 
 			if (typeof t.container == 'object') {
+				t.container.prev('.mejs-offscreen').remove();
 				t.container.remove();
 			}
 			t.globalUnbind();


### PR DESCRIPTION
If native controls are used on iPhone, iPad or Android devices,
t.container is never set, thus it can not be used. However the video
player title isn't built in that case and does not need to be removed.

Without this fix, calling .remove() on the mediaelement leads to an
error message on iPad, iPhone and Android if the native controls are
used.

As far as I can see there is no problem doing the removal of the video title later than before. An alternative would be to duplicate the if condition, however I think that is not necessary.