### PR TITLE
Fix removal of mediaelement when native controls are used

### DIFF
--- a/src/js/mediaelementplayer-player.js
+++ b/src/js/mediaelementplayer-player.js
@@ -1560,8 +1560,6 @@
 		remove: function () {
 			var t = this, featureIndex, feature;
 
-			t.container.prev('.mejs-offscreen').remove();
-
 			// invoke features cleanup
 			for (featureIndex in t.options.features) {
 				feature = t.options.features[featureIndex];
@@ -1599,6 +1597,7 @@
 			delete mejs.players[t.id];
 
 			if (typeof t.container === 'object') {
+				t.container.prev('.mejs-offscreen').remove();
 				t.container.remove();
 			}
 			t.globalUnbind();


### PR DESCRIPTION
If native controls are used on iPhone, iPad or Android devices,
t.container is never set, thus it can not be used. However the video
player title isn't built in that case and does not need to be removed.

Without this fix, calling .remove() on the mediaelement leads to an
error message on iPad, iPhone and Android if the native controls are
used.