### PR TITLE
Support multiple tracks of same language

### DIFF
--- a/src/js/mep-feature-tracks.js
+++ b/src/js/mep-feature-tracks.js
@@ -86,11 +86,11 @@
 				// click
 				player.captionsButton.on('click',function() {
 					if (player.selectedTrack === null) {
-						lang = player.tracks[0].srclang;
+						var trackId = player.tracks[0].trackId;
 					} else {
-						lang = 'none';
+						var trackId  = 'none';
 					}
-					player.setTrack(lang);
+					player.setTrack(trackId);
 				});
 			} else {
 				// hover or keyboard focus
@@ -100,8 +100,8 @@
 
 				// handle clicks to the language radio buttons
 				.on('click','input[type=radio]',function() {
-					lang = this.value;
-					player.setTrack(lang);
+					var trackId = this.id;
+					player.setTrack(trackId);
 				});
 
 				player.captionsButton.on( 'mouseleave focusout', function() {
@@ -136,7 +136,7 @@
 			for (i=0; i<player.tracks.length; i++) {
 				kind = player.tracks[i].kind;
 				if (kind === 'subtitles' || kind === 'captions') {
-					player.addTrackButton(player.tracks[i].srclang, player.tracks[i].label);
+					player.addTrackButton(player.tracks[i].trackId, player.tracks[i].srclang, player.tracks[i].label);
 				}
 			}
 
@@ -187,25 +187,23 @@
 			}
 		},
 
-		setTrack: function(lang){
+		setTrack: function(trackId){
 
 			var t = this,
 				i;
-
-			if (lang == 'none') {
-				t.selectedTrack = null;
-				t.captionsButton.removeClass('mejs-captions-enabled');
-			} else {
-				for (i=0; i<t.tracks.length; i++) {
-					if (t.tracks[i].srclang == lang) {
-						if (t.selectedTrack === null)
-							t.captionsButton.addClass('mejs-captions-enabled');
-						t.selectedTrack = t.tracks[i];
-						t.captions.attr('lang', t.selectedTrack.srclang);
-						t.displayCaptions();
-						break;
-					}
+		
+			for (i=0; i<t.tracks.length; i++) {
+				if (t.tracks[i].trackId == trackId) {
+					if (t.selectedTrack === null)
+						t.captionsButton.addClass('mejs-captions-enabled');
+					t.selectedTrack = t.tracks[i];
+					t.captions.attr('lang', t.selectedTrack.srclang);
+					t.displayCaptions();
+					break;
 				}
+			}
+			if (t.selectedTrack === null) {
+				t.captionsButton.removeClass('mejs-captions-enabled');
 			}
 		},
 
@@ -232,7 +230,7 @@
 
 					track.isLoaded = true;
 
-					t.enableTrackButton(track.srclang, track.label);
+					t.enableTrackButton(track);
 
 					t.loadNextTrack();
 
@@ -274,22 +272,22 @@
 			}
 		},
 
-		enableTrackButton: function(lang, label) {
-			var t = this;
+		enableTrackButton: function(track) {
+			var t = this, 
+					lang = track.lang, 
+					label = track.label;
 
 			if (label === '') {
 				label = mejs.language.codes[lang] || lang;
 			}
 
-			t.captionsButton
-				.find('input[value=' + lang + ']')
-					.prop('disabled',false)
-				.siblings('label')
-					.html( label );
+			$("#" + track.trackId).prop('disabled', false)
+					.siblings('label')
+					.html(label);
 
 			// auto select
 			if (t.options.startLanguage == lang) {
-				$('#' + t.id + '_captions_' + lang).prop('checked', true).trigger('click');
+				$("#" + track.trackId).prop('checked', true).trigger('click');
 			}
 
 			t.adjustLanguageBox();
@@ -303,7 +301,7 @@
 			t.adjustLanguageBox();
 		},
 
-		addTrackButton: function(lang, label) {
+		addTrackButton: function(trackId, lang, label) {
 			var t = this;
 			if (label === '') {
 				label = mejs.language.codes[lang] || lang;
@@ -311,8 +309,8 @@
 
 			t.captionsButton.find('ul').append(
 				$('<li>'+
-					'<input type="radio" name="' + t.id + '_captions" id="' + t.id + '_captions_' + lang + '" value="' + lang + '" disabled="disabled" />' +
-					'<label for="' + t.id + '_captions_' + lang + '">' + label + ' (loading)' + '</label>'+
+					'<input type="radio" name="' + t.id + '_captions" id="' + trackId + '" value="' + lang + '" disabled="disabled" />' +
+					'<label for="' + trackId + '">' + label + ' (loading)' + '</label>'+
 				'</li>')
 			);
 

--- a/src/js/mep-feature-tracks.js
+++ b/src/js/mep-feature-tracks.js
@@ -274,8 +274,8 @@
 
 		enableTrackButton: function(track) {
 			var t = this, 
-					lang = track.lang, 
-					label = track.label;
+				lang = track.lang, 
+				label = track.label;
 
 			if (label === '') {
 				label = mejs.language.codes[lang] || lang;

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1362,8 +1362,11 @@
 
 				track = $(track);
 
+				var srclang = (track.attr('srclang')) ? track.attr('srclang').toLowerCase() : '';
+				var trackId = t.id + '_track_' + index + '_' + track.attr('kind') + '_' + srclang;
 				t.tracks.push({
-					srclang: (track.attr('srclang')) ? track.attr('srclang').toLowerCase() : '',
+					trackId:  trackId,
+					srclang: srclang,
 					src: track.attr('src'),
 					kind: track.attr('kind'),
 					label: track.attr('label') || '',


### PR DESCRIPTION
This pull request fixes a couple oddities/bugs surrounding the assumption that a video will only have one track per language. I didn't file Issue reports, but I can if that's also desirable. Having two or more tracks of the same language produces the following bugs:
- addTrackButton() produces two labels with the same ID, which breaks the caption track selector UI partially
- setTrack() doesn't allow a user to activate the Nth track of a particular language
- enableTrackButton() incorrectly removes the "(loading)" with the content from a different track label. This markup 
```
<track kind="captions" src="" srclang="en" label="English" />
<track kind="subtitles" src="" srclang="en" label="English (Alt)" />
<track kind="subtitles" src="" srclang="en" label="More Subtitles" />
``` 
produces this broken UI: ![screen shot 2016-12-05 at 11 37 39 am](https://cloud.githubusercontent.com/assets/6674176/20895647/dd227b70-badf-11e6-87bf-4d0f03734d06.png)

---
Per the example below from in the [HTML5 spec](https://www.w3.org/TR/html5/embedded-content-0.html#the-track-element), I believe these changes in this PR result in a more-correct handling of track elements, as it appears to be acceptable to support multiple tracks of one language.
> This video has subtitles in several languages:
> 
> ```
> <video src="brave.webm">
>  <track kind=subtitles src=brave.en.vtt srclang=en label="English">
>  <track kind=captions src=brave.en.hoh.vtt srclang=en label="English for the Hard of Hearing">
>  <track kind=subtitles src=brave.fr.vtt srclang=fr lang=fr label="Français">
>  <track kind=subtitles src=brave.de.vtt srclang=de lang=de label="Deutsch">
> </video>
> ```
> (The lang attributes on the last two describe the language of the label attribute, not the language of the subtitles themselves. The language of the subtitles is given by the srclang attribute.)

While I'm not positive these changes represent a perfect changeset for handling track elements, these changes definitely fix bugs in a common use case: multiple tracks of the same language.