### PR TITLE
Use configurable classPrefix option for all class names

### DIFF
--- a/src/css/mediaelementplayer-simple.css
+++ b/src/css/mediaelementplayer-simple.css
@@ -1,12 +1,12 @@
 
-.mejs-simple-container {
+.mejs__simple-container {
 	background: #000;
 	margin: 10px 0;
 	position: relative;
 	min-height: 45px;
 }
 
-.mejs-simple-controls {
+.mejs__simple-controls {
 	position: absolute;
 	bottom: 0;
 	left: 0;
@@ -17,11 +17,11 @@
 	border: none;
 }
 
-.mejs-simple-video .mejs-simple-controls {
+.mejs__simple-video .mejs__simple-controls {
 }
 
 
-.mejs-simple-controls .ui-button {
+.mejs__simple-controls .ui-button {
 	display: block;
 	cursor: pointer;
 	float: left;
@@ -35,36 +35,36 @@
 	padding: 0;
 }
 
-.mejs-simple-controls .ui-button-play {
+.mejs__simple-controls .ui-button-play {
 	background-position: 0 0;
 }
 
-.mejs-simple-controls .ui-button-pause {
+.mejs__simple-controls .ui-button-pause {
 	background-position: 0 -25px;
 }
 
-.mejs-simple-controls .ui-button-unmuted {
+.mejs__simple-controls .ui-button-unmuted {
 	background-position: -25px -25px;
 }
 
-.mejs-simple-controls .ui-button-muted {
+.mejs__simple-controls .ui-button-muted {
 	background-position: -25px 0;
 }
 
-.mejs-simple-controls .ui-button-fullscreen,
-.mejs-simple-controls .ui-button-eixtfullscreen {
+.mejs__simple-controls .ui-button-fullscreen,
+.mejs__simple-controls .ui-button-eixtfullscreen {
 	margin-right: 10px;
 }
 
-.mejs-simple-controls .ui-button-fullscreen {
+.mejs__simple-controls .ui-button-fullscreen {
 	background-position: -50px 0px;
 }
 
-.mejs-simple-controls .ui-button-exitfullscreen {
+.mejs__simple-controls .ui-button-exitfullscreen {
 	background-position: -50px -25px;
 }
 
-.mejs-simple-controls .ui-time {
+.mejs__simple-controls .ui-time {
 	width: 32px;
 	height: 20px;
 	display: block;
@@ -75,7 +75,7 @@
 	text-align: center;
 }
 
-.mejs-simple-controls .ui-time-total {
+.mejs__simple-controls .ui-time-total {
 	width: 330px;
 	height: 10px;
 	float: left;
@@ -84,7 +84,7 @@
 	position: relative;
 }
 
-.mejs-simple-controls .ui-time-loaded {
+.mejs__simple-controls .ui-time-loaded {
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -93,7 +93,7 @@
 	background: #444444;
 }
 
-.mejs-simple-controls .ui-time-current {
+.mejs__simple-controls .ui-time-current {
 	position: absolute;
 	top: 0;
 	left: 0;

--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -1,6 +1,6 @@
 /* Accessibility: hide screen reader texts (and prefer "top" for RTL languages).
 Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-how/ */
-.mejs-offscreen {
+.mejs__offscreen {
 	clip: rect(1px, 1px, 1px, 1px); /* IE8-IE11 - no support for clip-path */
 	clip-path: polygon(0px 0px, 0px 0px,0px 0px, 0px 0px);
 	position: absolute !important;
@@ -9,7 +9,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	overflow: hidden;
 }
 
-.mejs-container {
+.mejs__container {
 	position: relative;
 	background: #000;
 	font-family: "Helvetica", Arial, serif;
@@ -19,25 +19,25 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 /* Hide native play button from iOS to favor plugin button */
-.mejs-container video::-webkit-media-controls-start-playback-button {
+.mejs__container video::-webkit-media-controls-start-playback-button {
 	display: none!important;
 	-webkit-appearance: none;
 }
 
-.mejs-fill-container,
-.mejs-fill-container .mejs-container {
+.mejs__fill-container,
+.mejs__fill-container .mejs__container {
 	width: 100%;
 	height: 100%;
 }
 
-.mejs-fill-container {
+.mejs__fill-container {
 	overflow: hidden;
 	position: relative;
 	margin: 0 auto;
 	background: transparent;
 }
 
-.mejs-container:focus {
+.mejs__container:focus {
 	outline: none;
 }
 
@@ -45,8 +45,8 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	position: absolute;
 }
 
-.mejs-embed,
-.mejs-embed body {
+.mejs__embed,
+.mejs__embed body {
 	width: 100%;
 	height: 100%;
 	margin: 0;
@@ -55,11 +55,11 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	overflow: hidden;
 }
 
-.mejs-fullscreen {
+.mejs__fullscreen {
 	overflow: hidden !important;
 }
 
-.mejs-container-fullscreen {
+.mejs__container-fullscreen {
 	position: fixed;
 	left: 0;
 	top: 0;
@@ -69,24 +69,24 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	z-index: 1000;
 }
 
-.mejs-container-fullscreen .mejs-mediaelement,
-.mejs-container-fullscreen video {
+.mejs__container-fullscreen .mejs__mediaelement,
+.mejs__container-fullscreen video {
 	width: 100%;
 	height: 100%;
 }
 
-.mejs-clear {
+.mejs__clear {
 	clear: both;
 }
 
 /* Start: LAYERS */
-.mejs-background {
+.mejs__background {
 	position: absolute;
 	top: 0;
 	left: 0;
 }
 
-.mejs-mediaelement {
+.mejs__mediaelement {
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -94,7 +94,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	height: 100%;
 }
 
-.mejs-poster {
+.mejs__poster {
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -103,26 +103,26 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	background-repeat: no-repeat;
 }
 
-:root .mejs-poster-img {
+:root .mejs__poster-img {
 	display: none;
 }
 
-.mejs-poster-img {
+.mejs__poster-img {
 	border: 0;
 	padding: 0;
 }
 
-.mejs-overlay {
+.mejs__overlay {
 	position: absolute;
 	top: 0;
 	left: 0;
 }
 
-.mejs-overlay-play {
+.mejs__overlay-play {
 	cursor: pointer;
 }
 
-.mejs-overlay-button {
+.mejs__overlay-button {
 	position: absolute;
 	top: 50%;
 	left: 50%;
@@ -132,11 +132,11 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	background: url("bigplay.svg") no-repeat;
 }
 
-.mejs-overlay:hover > .mejs-overlay-button {
+.mejs__overlay:hover > .mejs__overlay-button {
 	background-position: 0 -100px ;
 }
 
-.mejs-overlay-loading {
+.mejs__overlay-loading {
 	position: absolute;
 	top: 50%;
 	left: 50%;
@@ -147,7 +147,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	background: linear-gradient(rgba(50,50,50,0.9), rgba(0,0,0,0.9));
 }
 
-.mejs-overlay-loading-bg-img {
+.mejs__overlay-loading-bg-img {
 	display: block;
 	width: 80px;
 	height: 80px;
@@ -157,7 +157,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 /* End: LAYERS */
 
 /* Start: CONTROL BAR */
-.mejs-controls {
+.mejs__controls {
 	position: absolute;
 	list-style-type: none;
 	margin: 0;
@@ -168,14 +168,14 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	width: 100%;
 }
 
-.mejs-controls:not([style*="display: none"]) {
+.mejs__controls:not([style*="display: none"]) {
 	background: rgba(0, 0, 0, 0.7);
 	background: linear-gradient(rgba(50,50,50,0.7), rgba(0,0,0,0.7));
 }
 
-.mejs-button,
-.mejs-time,
-.mejs-time-rail {
+.mejs__button,
+.mejs__time,
+.mejs__time-rail {
 	float: left;
 	margin: 0;
 	width: 26px;
@@ -184,7 +184,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	line-height: 11px;
 }
 
-.mejs-button > button {
+.mejs__button > button {
 	cursor: pointer;
 	display: block;
 	font-size: 0;
@@ -200,22 +200,22 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 /* :focus for accessibility */
-.mejs-button > button:focus {
+.mejs__button > button:focus {
 	outline: dotted 1px #999;
 }
 
-.mejs-container-keyboard-inactive a,
-.mejs-container-keyboard-inactive a:focus,
-.mejs-container-keyboard-inactive button,
-.mejs-container-keyboard-inactive button:focus,
-.mejs-container-keyboard-inactive [role=slider],
-.mejs-container-keyboard-inactive [role=slider]:focus {
+.mejs__container-keyboard-inactive a,
+.mejs__container-keyboard-inactive a:focus,
+.mejs__container-keyboard-inactive button,
+.mejs__container-keyboard-inactive button:focus,
+.mejs__container-keyboard-inactive [role=slider],
+.mejs__container-keyboard-inactive [role=slider]:focus {
 	outline: 0;
 }
 /* End: CONTROL BAR */
 
 /* Start: Time (Current / Duration) */
-.mejs-time {
+.mejs__time {
 	color: #fff;
 	display: block;
 	height: 17px;
@@ -228,36 +228,36 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 /* End: Time (Current / Duration) */
 
 /* Start: Play/Pause/Stop */
-.mejs-play > button {
+.mejs__play > button {
 	background-position: 0 0;
 }
 
-.mejs-pause > button {
+.mejs__pause > button {
 	background-position: 0 -16px;
 }
 
-.mejs-stop > button {
+.mejs__stop > button {
 	background-position: -112px 0;
 }
 /* End: Play/Pause/Stop */
 
 /* Start: Progress Bar */
-.mejs-time-rail {
+.mejs__time-rail {
 	direction: ltr;
 	width: 200px;
 	padding-top: 5px;
 	position: relative;
 }
 
-.mejs-time-total,
-.mejs-time-buffering,
-.mejs-time-loaded,
-.mejs-time-current,
-.mejs-time-handle,
-.mejs-time-float,
-.mejs-time-float-current,
-.mejs-time-float-corner,
-.mejs-time-marker {
+.mejs__time-total,
+.mejs__time-buffering,
+.mejs__time-loaded,
+.mejs__time-current,
+.mejs__time-handle,
+.mejs__time-float,
+.mejs__time-float-current,
+.mejs__time-float-corner,
+.mejs__time-marker {
 	cursor: pointer;
 	display: block;
 	position: absolute;
@@ -265,14 +265,14 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	border-radius: 2px;
 }
 
-.mejs-time-total {
+.mejs__time-total {
 	margin: 5px;
 	background: rgba(50,50,50,0.8);
 	background: linear-gradient(rgba(30,30,30,0.8), rgba(60,60,60,0.8));
 	width: calc(100% - 10px);
 }
 
-.mejs-time-buffering {
+.mejs__time-buffering {
 	width: 100%;
 	background: linear-gradient(-45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 	background-size: 15px 15px;
@@ -281,19 +281,19 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 @keyframes buffering-stripes { from {background-position: 0 0;} to {background-position: 30px 0;} }
 
-.mejs-time-loaded {
+.mejs__time-loaded {
 	background: rgba(60,170,200,0.8);
 	background: linear-gradient(rgba(44,124,145,0.8), rgba(78,183,212,0.8));
 	width: 0;
 }
 
-.mejs-time-current {
+.mejs__time-current {
 	background: rgba(255,255,255,0.8);
 	background: linear-gradient(rgba(255,255,255,0.9), rgba(200,200,200,0.8));
 	width: 0;
 }
 
-.mejs-time-handle {
+.mejs__time-handle {
 	display: none;
 	position: absolute;
 	margin: 0;
@@ -306,7 +306,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	text-align: center;
 }
 
-.mejs-time-float {
+.mejs__time-float {
 	position: absolute;
 	display: none;
 	background: #eee;
@@ -319,7 +319,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	color: #111;
 }
 
-.mejs-time-float-current {
+.mejs__time-float-current {
 	margin: 2px;
 	width: 30px;
 	display: block;
@@ -327,7 +327,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	left: 0;
 }
 
-.mejs-time-float-corner {
+.mejs__time-float-corner {
 	position: absolute;
 	display: block;
 	width: 0;
@@ -340,45 +340,45 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	left: 13px;
 }
 
-.mejs-long-video .mejs-time-float {
+.mejs__long-video .mejs__time-float {
 	width: 48px;
 }
 
-.mejs-long-video .mejs-time-float-current {
+.mejs__long-video .mejs__time-float-current {
 	width: 44px;
 }
 
-.mejs-long-video .mejs-time-float-corner {
+.mejs__long-video .mejs__time-float-corner {
 	left: 18px;
 }
 
 /* End: Progress Bar */
 
 /* Start: Fullscreen */
-.mejs-fullscreen-button > button {
+.mejs__fullscreen-button > button {
 	background-position: -32px 0;
 }
 
-.mejs-unfullscreen > button {
+.mejs__unfullscreen > button {
 	background-position: -32px -16px;
 }
 /* End: Fullscreen */
 
 
 /* Start: Mute/Volume */
-.mejs-mute > button {
+.mejs__mute > button {
 	background-position: -16px -16px;
 }
 
-.mejs-unmute > button {
+.mejs__unmute > button {
 	background-position: -16px 0;
 }
 
-.mejs-volume-button {
+.mejs__volume-button {
 	position: relative;
 }
 
-.mejs-volume-button > .mejs-volume-slider {
+.mejs__volume-button > .mejs__volume-slider {
 	display: none;
 	height: 115px;
 	width: 25px;
@@ -391,11 +391,11 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	margin: 0;
 }
 
-.mejs-volume-button:hover {
+.mejs__volume-button:hover {
 	border-radius: 0 0 4px 4px;
 }
 
-.mejs-volume-total {
+.mejs__volume-total {
 	position: absolute;
 	left: 11px;
 	top: 8px;
@@ -406,7 +406,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	margin: 0;
 }
 
-.mejs-volume-current {
+.mejs__volume-current {
 	position: absolute;
 	left: 0;
 	bottom: 0;
@@ -417,7 +417,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	margin: 0;
 }
 
-.mejs-volume-handle {
+.mejs__volume-handle {
 	position: absolute;
 	left: 0;
 	bottom: 100%;
@@ -431,7 +431,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 
-.mejs-horizontal-volume-slider {
+.mejs__horizontal-volume-slider {
 	height: 26px;
 	width: 56px;
 	position: relative;
@@ -440,7 +440,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
     vertical-align: middle;
 }
 
-.mejs-horizontal-volume-total {
+.mejs__horizontal-volume-total {
 	position: absolute;
 	left: 0;
 	top: 11px;
@@ -454,7 +454,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	background: linear-gradient(rgba(30,30,30,0.8), rgba(60,60,60,0.8));
 }
 
-.mejs-horizontal-volume-current {
+.mejs__horizontal-volume-current {
 	position: absolute;
 	left: 0;
 	top: 0;
@@ -468,22 +468,22 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	background: linear-gradient(rgba(255,255,255,0.9), rgba(200,200,200,0.8));
 }
 
-.mejs-horizontal-volume-handle {
+.mejs__horizontal-volume-handle {
 	display: none;
 }
 
 /* End: Mute/Volume */
 
 /* Start: Track (Captions and Chapters) */
-.mejs-captions-button {
+.mejs__captions-button {
 	position: relative;
 }
 
-.mejs-captions-button > button {
+.mejs__captions-button > button {
 	background-position: -48px 0;
 }
 
-.mejs-captions-button > .mejs-captions-selector {
+.mejs__captions-button > .mejs__captions-selector {
 	visibility: hidden;
 	position: absolute;
 	bottom: 26px;
@@ -497,11 +497,11 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	border-radius: 0;
 }
 
-.mejs-captions-button > .mejs-captions-selector {
+.mejs__captions-button > .mejs__captions-selector {
 	visibility: visible;
 }
 
-.mejs-captions-selector-list {
+.mejs__captions-selector-list {
 	margin: 0;
 	padding: 0;
 	display: block;
@@ -509,7 +509,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	overflow: hidden;
 }
 
-.mejs-captions-selector-list-item {
+.mejs__captions-selector-list-item {
 	margin: 0 0 6px 0;
 	padding: 0 10px;
 	list-style-type: none !important;
@@ -517,12 +517,12 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	color: #fff;
 	overflow: hidden;
 }
-.mejs-captions-selector-list-item:hover {
+.mejs__captions-selector-list-item:hover {
 	background-color: rgb(200, 200, 200) !important;
 	background-color: rgba(255, 255, 255, 0.4) !important;
 }
 
-.mejs-captions-selector-input {
+.mejs__captions-selector-input {
 	clear: both;
 	float: left;
 	margin: 3px 3px 0 5px;
@@ -530,7 +530,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	left: -1000px;
 }
 
-.mejs-captions-selector-label {
+.mejs__captions-selector-label {
 	width: 55px;
 	float: left;
 	padding: 4px 0 0 0;
@@ -538,16 +538,16 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	font-size: 10px;
 }
 
-.mejs-captions-selected {
+.mejs__captions-selected {
 	color: rgba(33, 248, 248, 1);
 }
 
-.mejs-captions-translations {
+.mejs__captions-translations {
 	font-size: 10px;
 	margin: 0 0 5px 0;
 }
 
-.mejs-chapters {
+.mejs__chapters {
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -556,7 +556,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	z-index: 1;
 }
 
-.mejs-chapter {
+.mejs__chapter {
 	position: absolute;
 	float: left;
 	background: rgba(0, 0, 0, 0.7);
@@ -565,7 +565,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	border: 0;
 }
 
-.mejs-chapter-block {
+.mejs__chapter-block {
 	font-size: 11px;
 	color: #fff;
 	padding: 5px;
@@ -575,16 +575,16 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	cursor: pointer;
 }
 
-.mejs-chapter-block-last {
+.mejs__chapter-block-last {
 	border-right: none;
 }
 
-.mejs-chapter-block:hover {
+.mejs__chapter-block:hover {
 	background: rgba(102,102,102, 0.7);
 	background: linear-gradient(rgba(102,102,102,0.7), rgba(50,50,50,0.6));
 }
 
-.mejs-chapter-block .ch-title {
+.mejs__chapter-block .ch-title {
 	font-size: 12px;
 	font-weight: bold;
 	display: block;
@@ -594,7 +594,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	line-height: 12px;
 }
 
-.mejs-chapter-block .ch-timespan {
+.mejs__chapter-block .ch-timespan {
 	font-size: 12px;
 	line-height: 12px;
 	margin: 3px 0 4px 0;
@@ -603,7 +603,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	text-overflow: ellipsis;
 }
 
-.mejs-captions-layer {
+.mejs__captions-layer {
 	position: absolute;
 	bottom: 0;
 	left: 0;
@@ -613,28 +613,28 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	color: #fff;
 }
 
-.mejs-captions-layer a {
+.mejs__captions-layer a {
 	color: #fff;
 	text-decoration: underline;
 }
 
-.mejs-captions-layer[lang=ar] {
+.mejs__captions-layer[lang=ar] {
 	font-size: 20px;
 	font-weight: normal;
 }
 
-.mejs-captions-position {
+.mejs__captions-position {
 	position: absolute;
 	width: 100%;
 	bottom: 15px;
 	left: 0;
 }
 
-.mejs-captions-position-hover {
+.mejs__captions-position-hover {
 	bottom: 35px;
 }
 
-.mejs-captions-text {
+.mejs__captions-text {
 	padding: 0;
 	background: rgba(20, 20, 20, 0.5);
 	white-space: pre-wrap;
@@ -656,18 +656,18 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 
 /* Start: Loop */
-.mejs-loop-off > button {
+.mejs__loop-off > button {
 	background-position: -64px -16px;
 }
 
-.mejs-loop-on > button {
+.mejs__loop-on > button {
 	background-position: -64px 0;
 }
 /* End: Loop */
 
 
 /* context menu */
-.mejs-contextmenu {
+.mejs__contextmenu {
 	position: absolute;
 	width: 150px;
 	padding: 10px;
@@ -679,35 +679,35 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	z-index: 1001; /* make sure it shows on fullscreen */
 }
 
-.mejs-contextmenu-separator {
+.mejs__contextmenu-separator {
 	height: 1px;
 	font-size: 0;
 	margin: 5px 6px;
 	background: #333;
 }
 
-.mejs-contextmenu-item {
+.mejs__contextmenu-item {
 	font-size: 12px;
 	padding: 4px 6px;
 	cursor: pointer;
 	color: #333;
 }
 
-.mejs-contextmenu-item:hover {
+.mejs__contextmenu-item:hover {
 	background: #2C7C91;
 	color: #fff;
 }
 
 /* Start: Source Chooser */
-.mejs-sourcechooser-button {
+.mejs__sourcechooser-button {
 	position: relative;
 }
 
-.mejs-sourcechooser-button > button {
+.mejs__sourcechooser-button > button {
 	background-position: -128px 0;
 }
 
-.mejs-sourcechooser-button .mejs-sourcechooser-selector {
+.mejs__sourcechooser-button .mejs__sourcechooser-selector {
 	position: absolute;
 	bottom: 26px;
 	right: -10px;
@@ -720,7 +720,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	border-radius: 0;
 }
 
-.mejs-sourcechooser-selector ul {
+.mejs__sourcechooser-selector ul {
 	margin: 0;
 	padding: 0;
 	display: block;
@@ -728,7 +728,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	overflow: hidden;
 }
 
-.mejs-sourcechooser-selector li {
+.mejs__sourcechooser-selector li {
 	margin: 0 0 6px 0;
 	padding: 0;
 	list-style-type: none !important;
@@ -737,13 +737,13 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	overflow: hidden;
 }
 
-.mejs-sourcechooser-selector input {
+.mejs__sourcechooser-selector input {
 	clear: both;
 	float: left;
 	margin: 3px 3px 0 5px;
 }
 
-.mejs-sourcechooser-selector label {
+.mejs__sourcechooser-selector label {
 	width: 100px;
 	float: left;
 	padding: 4px 0 0 0;
@@ -753,7 +753,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 /* End: Source Chooser */
 
 /* Start: Postroll */
-.mejs-postroll-layer {
+.mejs__postroll-layer {
 	position: absolute;
 	bottom: 0;
 	left: 0;
@@ -764,11 +764,11 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	overflow: hidden;
 }
 
-.mejs-postroll-layer-content {
+.mejs__postroll-layer-content {
 	width: 100%;
 	height: 100%;
 }
-.mejs-postroll-close {
+.mejs__postroll-close {
 	position: absolute;
 	right: 0;
 	top: 0;
@@ -781,12 +781,12 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 /* End: Postroll */
 
 /* Start: Speed */
-.mejs-speed-button {
+.mejs__speed-button {
 	width: 46px !important;
 	position: relative;
 }
 
-.mejs-speed-button > button {
+.mejs__speed-button > button {
 	background: transparent;
 	width: 36px;
 	font-size: 11px;
@@ -794,7 +794,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	color: #ffffff;
 }
 
-.mejs-speed-selector {
+.mejs__speed-selector {
 	visibility: hidden;
 	position: absolute;
 	top: -100px;
@@ -808,11 +808,11 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	border-radius: 0;
 }
 
-.mejs-speed-selector {
+.mejs__speed-selector {
 	visibility: visible;
 }
 
-.mejs-speed-selector-list {
+.mejs__speed-selector-list {
 	margin: 0;
 	padding: 0;
 	display: block;
@@ -820,7 +820,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	overflow: hidden;
 }
 
-.mejs-speed-selector-list-item {
+.mejs__speed-selector-list-item {
 	margin: 0 0 6px 0;
 	padding: 0 10px;
 	list-style-type: none !important;
@@ -829,12 +829,12 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	overflow: hidden;
 }
 
-.mejs-speed-selector-list-item:hover {
+.mejs__speed-selector-list-item:hover {
 	background-color: rgb(200, 200, 200) !important;
 	background-color: rgba(255, 255, 255, 0.4) !important;
 }
 
-.mejs-speed-selector-input {
+.mejs__speed-selector-input {
 	clear: both;
 	float: left;
 	margin: 3px 3px 0 5px;
@@ -842,7 +842,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	left: -1000px;
 }
 
-.mejs-speed-selector-label {
+.mejs__speed-selector-label {
 	width: 60px;
 	float: left;
 	padding: 4px 0 0 0;
@@ -853,17 +853,17 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 	cursor: pointer;
 }
 
-.mejs-speed-selected {
+.mejs__speed-selected {
 	color: rgba(33, 248, 248, 1);
 }
 /* End: Speed */
 
 /* Start: Jump Forward */
-.mejs-jump-forward-button {
+.mejs__jump-forward-button {
 	background: transparent url("jumpforward.png") no-repeat 3px 3px;
 }
 
-.mejs-jump-forward-button button {
+.mejs__jump-forward-button button {
 	background: transparent;
 	font-size: 9px;
 	line-height: normal;
@@ -872,11 +872,11 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 /* End: Jump Forward */
 
 /* Start: Skip Back */
-.mejs-skip-back-button {
+.mejs__skip-back-button {
 	background: transparent url("skipback.png") no-repeat 3px 3px;
 }
 
-.mejs-skip-back-button > button {
+.mejs__skip-back-button > button {
 	background: transparent;
 	font-size: 9px;
 	line-height: normal;

--- a/src/js/mediaelementplayer-feature-ads.js
+++ b/src/js/mediaelementplayer-feature-ads.js
@@ -13,7 +13,7 @@
 
 	// on time insert into head
 	$('head').append($('<style>' +
-'.mejs-ads a {' +
+'.mejs__ads a {' +
 '	display: block; ' +
 '	position: absolute;' +
 '	right: 0;' +
@@ -22,7 +22,7 @@
 '	height: 100%; ' +
 '	display: block; ' +
 '}' +
-'.mejs-ads .mejs-ads-skip-block {' +
+'.mejs__ads .mejs__ads-skip-block {' +
 '	display: block; ' +
 '	position: absolute;' +
 '	right: 0;' +
@@ -32,10 +32,10 @@
 '	background: rgba(0,0,0,0.5); ' +
 '	color: #fff; ' +
 '}' +
-'.mejs-ads .mejs-ads-skip-button {' +
+'.mejs__ads .mejs__ads-skip-button {' +
 '	cursor: pointer; ' +
 '}' +
-'.mejs-ads .mejs-ads-skip-button:hover {' +
+'.mejs__ads .mejs__ads-skip-button:hover {' +
 '	text-decoration: underline; ' +
 '}' +
 	'</style>'));
@@ -87,21 +87,29 @@
 
 			// add layer for ad links and skipping
 			player.adsLayer =
-					$('<div class="mejs-layer mejs-overlay mejs-ads">' +
+					$('<div class="' + t.options.classPrefix + 'layer ' +
+					                   t.options.classPrefix + 'overlay ' +
+									   t.options.classPrefix + 'ads">' +
 							'<a href="#" target="_blank">&nbsp;</a>' +
-							'<div class="mejs-ads-skip-block">' +
-								'<span class="mejs-ads-skip-message"></span>' +
-								'<span class="mejs-ads-skip-button">' + mejs.i18n.t('mejs.ad-skip') + '&raquo;</span>' +
+							'<div class="' + t.options.classPrefix + 'ads-skip-block">' +
+								'<span class="' + t.options.classPrefix + 'ads-skip-message"></span>' +
+								'<span class="' + t.options.classPrefix + 'ads-skip-button">' +
+									mejs.i18n.t('mejs.ad-skip') + '&raquo;' +
+								'</span>' +
 							'</div>' +
 						'</div>')
-							.insertBefore( layers.find('.mejs-overlay-play') )
-							.hide();
+						.insertBefore( layers.find('.' + t.options.classPrefix + 'overlay-play') )
+						.hide();
 
-			player.adsLayer.find('a').on('click', $.proxy(t.adsAdClick, t) );
+			player.adsLayer.find('a')
+				.on('click', $.proxy(t.adsAdClick, t) );
 
-			player.adsSkipBlock = player.adsLayer.find('.mejs-ads-skip-block').hide();
-			player.adsSkipMessage = player.adsLayer.find('.mejs-ads-skip-message').hide();
-			player.adsSkipButton = player.adsLayer.find('.mejs-ads-skip-button').on('click', $.proxy(t.adsSkipClick, t));
+			player.adsSkipBlock = player.adsLayer.find('.' + t.options.classPrefix + 'mejs__ads-skip-block')
+				.hide();
+			player.adsSkipMessage = player.adsLayer.find('.' + t.options.classPrefix + 'mejs__ads-skip-message')
+				.hide();
+			player.adsSkipButton = player.adsLayer.find('.' + t.options.classPrefix + 'mejs__ads-skip-button')
+				.on('click', $.proxy(t.adsSkipClick, t));
 
 			// create proxies (only needed for events we want to remove later)
 			t.adsMediaTryingToStartProxy = 	$.proxy(t.adsMediaTryingToStart, t);
@@ -175,7 +183,7 @@
 			}
 
 			setTimeout(function() {
-				t.controls.find('.mejs-duration').html(
+				t.controls.find('.mejs__duration').html(
 					mejs.Utility.secondsToTimeCode(newDuration, t.options.alwaysShowHours)
 				);
 			}, 250);

--- a/src/js/mediaelementplayer-feature-contextmenu.js
+++ b/src/js/mediaelementplayer-feature-contextmenu.js
@@ -68,7 +68,7 @@ $.extend(mejs.MepDefaults,
 		buildcontextmenu: function(player, controls, layers, media) {
 
 			// create context menu
-			player.contextMenu = $('<div class="mejs-contextmenu"></div>')
+			player.contextMenu = $('<div class="' + t.options.classPrefix + 'contextmenu"></div>')
 								.appendTo($('body'))
 								.hide();
 
@@ -135,14 +135,15 @@ $.extend(mejs.MepDefaults,
 			for (var i=0, il=items.length; i<il; i++) {
 
 				if (items[i].isSeparator) {
-					html += '<div class="mejs-contextmenu-separator"></div>';
+					html += '<div class="' + t.options.classPrefix + 'contextmenu-separator"></div>';
 				} else {
 
 					var rendered = items[i].render(t);
 
 					// render can return null if the item doesn't need to be used at the moment
 					if (rendered !== null && rendered !== undefined) {
-						html += '<div class="mejs-contextmenu-item" data-itemindex="' + i + '" id="element-' + (Math.random()*1000000) + '">' + rendered + '</div>';
+						html += '<div class="' + t.options.classPrefix + 'contextmenu-item"' +
+							'data-itemindex="' + i + '" id="element-' + (Math.random()*1000000) + '">' + rendered + '</div>';
 					}
 				}
 			}
@@ -155,7 +156,7 @@ $.extend(mejs.MepDefaults,
 				.show();
 
 			// bind events
-			t.contextMenu.find('.mejs-contextmenu-item').each(function() {
+			t.contextMenu.find('.' + t.options.classPrefix + 'contextmenu-item').each(function() {
 
 				// which one is this?
 				var $dom = $(this),

--- a/src/js/mediaelementplayer-feature-fullscreen.js
+++ b/src/js/mediaelementplayer-feature-fullscreen.js
@@ -78,8 +78,10 @@
 				hideTimeout = null,
 				fullscreenTitle = t.options.fullscreenText ? t.options.fullscreenText : mejs.i18n.t('mejs.fullscreen'),
 				fullscreenBtn =
-					$('<div class="mejs-button mejs-fullscreen-button">' +
-						'<button type="button" aria-controls="' + t.id + '" title="' + fullscreenTitle + '" aria-label="' + fullscreenTitle + '"></button>' +
+					$('<div class="' + t.options.classPrefix + 'button ' +
+					                   t.options.classPrefix + 'fullscreen-button">' +
+						'<button type="button" aria-controls="' + t.id + '" title="' + fullscreenTitle +
+							'" aria-label="' + fullscreenTitle + '"></button>' +
 						'</div>')
 					.appendTo(controls)
 					.on('click', function () {
@@ -287,7 +289,8 @@
 			});
 
 			for (i = 0, len = hoverDivNames.length; i < len; i++) {
-				hoverDivs[hoverDivNames[i]] = $('<div class="mejs-fullscreen-hover" />').appendTo(t.container).mouseover(restoreControls).hide();
+				hoverDivs[hoverDivNames[i]] = $('<div class="' + t.options.classPrefix + 'fullscreen-hover" />')
+					.appendTo(t.container).mouseover(restoreControls).hide();
 			}
 
 			// on hover, kill the fullscreen button's HTML handling, allowing clicks down to Flash
@@ -386,7 +389,7 @@
 			}
 
 			// set it to not show scroll bars so 100% will work
-			$(document.documentElement).addClass('mejs-fullscreen');
+			$(document.documentElement).addClass(t.options.classPrefix + 'fullscreen');
 
 			// store sizing
 			t.normalHeight = t.container.height();
@@ -431,7 +434,7 @@
 
 			// make full size
 			t.container
-			.addClass('mejs-container-fullscreen')
+			.addClass(t.options.classPrefix + 'container-fullscreen')
 			.width('100%')
 			.height('100%');
 
@@ -464,17 +467,20 @@
 
 			if (t.fullscreenBtn) {
 				t.fullscreenBtn
-				.removeClass('mejs-fullscreen')
-				.addClass('mejs-unfullscreen');
+				.removeClass(t.options.classPrefix + 'fullscreen')
+				.addClass(t.options.classPrefix + 'unfullscreen');
 			}
 
 			t.setControlsSize();
 			t.isFullScreen = true;
 
 			var zoomFactor = Math.min(screen.width / t.width, screen.height / t.height);
-			t.container.find('.mejs-captions-text').css('font-size', zoomFactor * 100 + '%');
-			t.container.find('.mejs-captions-text').css('line-height', 'normal');
-			t.container.find('.mejs-captions-position').css('bottom', '45px');
+			t.container.find('.' + t.options.classPrefix + 'captions-text')
+				.css('font-size', zoomFactor * 100 + '%');
+			t.container.find('.' + t.options.classPrefix + 'captions-text')
+				.css('line-height', 'normal');
+			t.container.find('.' + t.options.classPrefix + 'captions-position')
+				.css('bottom', '45px');
 
 			t.container.trigger('enteredfullscreen');
 		},
@@ -498,9 +504,9 @@
 			}
 
 			// restore scroll bars to document
-			$(document.documentElement).removeClass('mejs-fullscreen');
+			$(document.documentElement).removeClass(t.options.classPrefix + 'fullscreen');
 
-			t.container.removeClass('mejs-container-fullscreen');
+			t.container.removeClass(t.options.classPrefix + 'container-fullscreen');
 
 			if (t.options.setDimensions) {
 				t.container.width(t.normalWidth)
@@ -523,15 +529,18 @@
 			}
 
 			t.fullscreenBtn
-			.removeClass('mejs-unfullscreen')
-			.addClass('mejs-fullscreen');
+			.removeClass(t.options.classPrefix + 'unfullscreen')
+			.addClass(t.options.classPrefix + 'fullscreen');
 
 			t.setControlsSize();
 			t.isFullScreen = false;
 
-			t.container.find('.mejs-captions-text').css('font-size','');
-			t.container.find('.mejs-captions-text').css('line-height', '');
-			t.container.find('.mejs-captions-position').css('bottom', '');
+			t.container.find('.' + t.options.classPrefix + 'captions-text')
+				.css('font-size','');
+			t.container.find('.' + t.options.classPrefix + 'captions-text')
+				.css('line-height', '');
+			t.container.find('.' + t.options.classPrefix + 'captions-position')
+				.css('bottom', '');
 
 			t.container.trigger('exitedfullscreen');
 		}

--- a/src/js/mediaelementplayer-feature-jumpforward.js
+++ b/src/js/mediaelementplayer-feature-jumpforward.js
@@ -34,9 +34,13 @@
 				forwardTitle = t.options.jumpForwardText ? t.options.jumpForwardText.replace('%1', t.options.jumpForwardInterval) : defaultTitle,
 				// create the loop button
 				loop =
-					$('<div class="mejs-button mejs-jump-forward-button">' +
-						'<button type="button" aria-controls="' + t.id + '" title="' + forwardTitle + '" aria-label="' + forwardTitle + '">' + t.options.jumpForwardInterval + '</button>' +
-						'</div>')
+					$('<div class="' + t.options.classPrefix + 'button ' +
+					                   t.options.classPrefix + 'jump-forward-button">' +
+						'<button type="button" aria-controls="' + t.id + '" title="' + forwardTitle + '" ' +
+							'aria-label="' + forwardTitle + '">' +
+							t.options.jumpForwardInterval +
+						'</button>' +
+					'</div>')
 					// append it to the toolbar
 					.appendTo(controls)
 					// add a click toggle event

--- a/src/js/mediaelementplayer-feature-loop.js
+++ b/src/js/mediaelementplayer-feature-loop.js
@@ -21,8 +21,12 @@
 				t = this,
 				// create the loop button
 				loop =
-				$('<div class="mejs-button mejs-loop-button ' + ((player.options.loop) ? 'mejs-loop-on' : 'mejs-loop-off') + '">' +
-					'<button type="button" aria-controls="' + t.id + '" title="Toggle Loop" aria-label="Toggle Loop"></button>' +
+				$('<div class="' + t.options.classPrefix + 'button ' +
+				                   t.options.classPrefix + 'loop-button ' +
+					((player.options.loop) ? t.options.classPrefix + 'loop-on' :
+					                         t.options.classPrefix + 'loop-off') + '">' +
+					'<button type="button" aria-controls="' + t.id + '" ' +
+						'title="Toggle Loop" aria-label="Toggle Loop"></button>' +
 				'</div>')
 				// append it to the toolbar
 				.appendTo(controls)
@@ -30,9 +34,11 @@
 				.click(function() {
 					player.options.loop = !player.options.loop;
 					if (player.options.loop) {
-						loop.removeClass('mejs-loop-off').addClass('mejs-loop-on');
+						loop.removeClass(t.options.classPrefix + 'loop-off')
+							.addClass(t.options.classPrefix + 'loop-on');
 					} else {
-						loop.removeClass('mejs-loop-on').addClass('mejs-loop-off');
+						loop.removeClass(t.options.classPrefix + 'loop-on')
+							.addClass(t.options.classPrefix + 'loop-off');
 					}
 				});
 		}

--- a/src/js/mediaelementplayer-feature-markers.js
+++ b/src/js/mediaelementplayer-feature-markers.js
@@ -46,7 +46,8 @@
 				lastMarkerCallBack = -1; //Prevents successive firing of callbacks
 
 			for (i = 0; i < player.options.markers.length; ++i) {
-				controls.find('.mejs-time-total').append('<span class="mejs-time-marker"></span>');
+				controls.find('.' + t.options.classPrefix + 'time-total')
+					.append('<span class="' + t.options.classPrefix + 'time-marker"></span>');
 			}
 
 			media.addEventListener('durationchange', function (e) {
@@ -86,7 +87,7 @@
 			for (i = 0; i < t.options.markers.length; ++i) {
 				if (Math.floor(t.options.markers[i]) <= t.media.duration && Math.floor(t.options.markers[i]) >= 0) {
 					left = 100 * Math.floor(t.options.markers[i]) / t.media.duration;
-					$(controls.find('.mejs-time-marker')[i]).css({
+					$(controls.find('.' + t.options.classPrefix + 'time-marker')[i]).css({
 						"width": "1px",
 						"left": left + "%",
 						"background": t.options.markerColor

--- a/src/js/mediaelementplayer-feature-playpause.js
+++ b/src/js/mediaelementplayer-feature-playpause.js
@@ -36,8 +36,11 @@
 				playTitle = op.playText ? op.playText : mejs.i18n.t('mejs.play'),
 				pauseTitle = op.pauseText ? op.pauseText : mejs.i18n.t('mejs.pause'),
 				play =
-				$('<div class="mejs-button mejs-playpause-button mejs-play" >' +
-					'<button type="button" aria-controls="' + t.id + '" title="' + playTitle + '" aria-label="' + pauseTitle + '"></button>' +
+				$('<div class="' + t.options.classPrefix + 'button ' +
+				                   t.options.classPrefix + 'playpause-button ' +
+								   t.options.classPrefix + 'play" >' +
+					'<button type="button" aria-controls="' + t.id + '" title="' + playTitle + '" ' +
+						'aria-label="' + pauseTitle + '"></button>' +
 				'</div>')
 				.appendTo(controls)
 				.click(function() {
@@ -56,13 +59,15 @@
 			 */
 			function togglePlayPause(which) {
 				if ('play' === which) {
-					play.removeClass('mejs-play').addClass('mejs-pause');
+					play.removeClass(t.options.classPrefix + 'play')
+						.addClass(t.options.classPrefix + 'pause');
 					play_btn.attr({
 						'title': pauseTitle,
 						'aria-label': pauseTitle
 					});
 				} else {
-					play.removeClass('mejs-pause').addClass('mejs-play');
+					play.removeClass(t.options.classPrefix + 'pause')
+						.addClass(t.options.classPrefix + 'play');
 					play_btn.attr({
 						'title': playTitle,
 						'aria-label': playTitle

--- a/src/js/mediaelementplayer-feature-postroll.js
+++ b/src/js/mediaelementplayer-feature-postroll.js
@@ -34,11 +34,13 @@
 
 			if (postrollLink !== undefined) {
 				player.postroll =
-					$('<div class="mejs-postroll-layer mejs-layer">' +
-						'<a class="mejs-postroll-close" onclick="$(this).parent().hide();return false;">' +
+					$('<div class="' + t.options.classPrefix + 'postroll-layer ' +
+					                   t.options.classPrefix + 'layer">' +
+						'<a class="' + t.options.classPrefix + 'postroll-close" ' +
+							'onclick="$(this).parent().hide();return false;">' +
 							postrollTitle +
 						'</a>' +
-					'<div class="mejs-postroll-layer-content"></div></div>')
+					'<div class="' + t.options.classPrefix + 'postroll-layer-content"></div></div>')
 						.prependTo(layers).hide();
 
 				t.media.addEventListener('ended', function (e) {
@@ -46,7 +48,7 @@
 						dataType: 'html',
 						url: postrollLink,
 						success: function (data, textStatus) {
-							layers.find('.mejs-postroll-layer-content').html(data);
+							layers.find('.' + t.options.classPrefix + 'postroll-layer-content').html(data);
 						}
 					});
 					player.postroll.show();

--- a/src/js/mediaelementplayer-feature-progress.js
+++ b/src/js/mediaelementplayer-feature-progress.js
@@ -39,31 +39,32 @@
 				startedPaused = false,
 				autoRewindInitial = player.options.autoRewind,
 				progressTitle = t.options.progressHelpText ? t.options.progressHelpText : mejs.i18n.t('mejs.time-help-text'),
-				tooltip = player.options.enableProgressTooltip ? '<span class="mejs-time-float">' +
-				'<span class="mejs-time-float-current">00:00</span>' +
-				'<span class="mejs-time-float-corner"></span>' +
+				tooltip = player.options.enableProgressTooltip ? '<span class="' + t.options.classPrefix + 'time-float">' +
+				'<span class="' + t.options.classPrefix + 'time-float-current">00:00</span>' +
+				'<span class="' + t.options.classPrefix + 'time-float-corner"></span>' +
 				'</span>' : "";
 
-			$('<div class="mejs-time-rail">' +
-				'<span  class="mejs-time-total mejs-time-slider">' +
-				//'<span class="mejs-offscreen">' + progressTitle + '</span>' +
-				'<span class="mejs-time-buffering"></span>' +
-				'<span class="mejs-time-loaded"></span>' +
-				'<span class="mejs-time-current"></span>' +
-				'<span class="mejs-time-handle"></span>' +
+			$('<div class="' + t.options.classPrefix + 'time-rail">' +
+				'<span class="' + t.options.classPrefix + 'time-total ' +
+				                  t.options.classPrefix + 'time-slider">' +
+				//'<span class="' + t.options.classPrefix + 'mejs__offscreen">' + progressTitle + '</span>' +
+				'<span class="' + t.options.classPrefix + 'time-buffering"></span>' +
+				'<span class="' + t.options.classPrefix + 'time-loaded"></span>' +
+				'<span class="' + t.options.classPrefix + 'time-current"></span>' +
+				'<span class="' + t.options.classPrefix + 'time-handle"></span>' +
 				tooltip +
 				'</span>' +
 				'</div>')
 			.appendTo(controls);
-			controls.find('.mejs-time-buffering').hide();
+			controls.find('.' + t.options.classPrefix + 'time-buffering').hide();
 
-			t.total = controls.find('.mejs-time-total');
-			t.loaded = controls.find('.mejs-time-loaded');
-			t.current = controls.find('.mejs-time-current');
-			t.handle = controls.find('.mejs-time-handle');
-			t.timefloat = controls.find('.mejs-time-float');
-			t.timefloatcurrent = controls.find('.mejs-time-float-current');
-			t.slider = controls.find('.mejs-time-slider');
+			t.total = controls.find('.' + t.options.classPrefix + 'time-total');
+			t.loaded = controls.find('.' + t.options.classPrefix + 'time-loaded');
+			t.current = controls.find('.' + t.options.classPrefix + 'time-current');
+			t.handle = controls.find('.' + t.options.classPrefix + 'time-handle');
+			t.timefloat = controls.find('.' + t.options.classPrefix + 'time-float');
+			t.timefloatcurrent = controls.find('.' + t.options.classPrefix + 'time-float-current');
+			t.slider = controls.find('.' + t.options.classPrefix + 'time-slider');
 
 			/**
 			 *

--- a/src/js/mediaelementplayer-feature-skipback.js
+++ b/src/js/mediaelementplayer-feature-skipback.js
@@ -35,8 +35,12 @@
 				skipTitle = t.options.skipBackText ? t.options.skipBackText.replace('%1', t.options.skipBackInterval) : defaultTitle,
 				// create the loop button
 				loop =
-					$('<div class="mejs-button mejs-skip-back-button">' +
-						'<button type="button" aria-controls="' + t.id + '" title="' + skipTitle + '" aria-label="' + skipTitle + '">' + t.options.skipBackInterval + '</button>' +
+					$('<div class="' + t.options.classPrefix + 'button ' +
+					                   t.options.classPrefix + 'skip-back-button">' +
+						'<button type="button" aria-controls="' + t.id + '" ' +
+							'title="' + skipTitle + '" aria-label="' + skipTitle + '">' +
+							t.options.skipBackInterval +
+						'</button>' +
 					'</div>')
 					// append it to the toolbar
 					.appendTo(controls)

--- a/src/js/mediaelementplayer-feature-sourcechooser.js
+++ b/src/js/mediaelementplayer-feature-sourcechooser.js
@@ -47,9 +47,15 @@
 			}
 
 			player.sourcechooserButton =
-				$('<div class="mejs-button mejs-sourcechooser-button">' +
-					'<button type="button" role="button" aria-haspopup="true" aria-owns="' + t.id + '" title="' + sourceTitle + '" aria-label="' + sourceTitle + '"></button>' +
-					'<div class="mejs-sourcechooser-selector mejs-offscreen" role="menu" aria-expanded="false" aria-hidden="true">' +
+				$('<div class="' + t.options.classPrefix + 'button ' +
+				                   t.options.classPrefix + 'sourcechooser-button">' +
+					'<button type="button" role="button" aria-haspopup="true" ' +
+						'aria-owns="' + t.id + '" title="' + sourceTitle + '" ' +
+						'aria-label="' + sourceTitle +
+					'"></button>' +
+					'<div class="' + t.options.classPrefix + 'sourcechooser-selector ' +
+					                 t.options.classPrefix + 'offscreen" role="menu" ' +
+						'aria-expanded="false" aria-hidden="true">' +
 					'<ul>' +
 					'</ul>' +
 					'</div>' +
@@ -75,12 +81,12 @@
 							if (!mejs.MediaFeatures.isFirefox) { // space sends the click event in Firefox
 								player.showSourcechooserSelector();
 							}
-							$(this).find('.mejs-sourcechooser-selector')
+							$(this).find('.' + t.options.classPrefix + 'sourcechooser-selector')
 							.find('input[type=radio]:checked').first().focus();
 							break;
 						case 13: // enter
 							player.showSourcechooserSelector();
-							$(this).find('.mejs-sourcechooser-selector')
+							$(this).find('.' + t.options.classPrefix + 'sourcechooser-selector')
 							.find('input[type=radio]:checked').first().focus();
 							break;
 						case 27: // esc
@@ -97,7 +103,7 @@
 					// Firefox does NOT support e.relatedTarget to see which element
 					// just lost focus, so wait to find the next focused element
 					setTimeout(function () {
-						var parent = $(document.activeElement).closest('.mejs-sourcechooser-selector');
+						var parent = $(document.activeElement).closest('.' + t.options.classPrefix + 'sourcechooser-selector');
 						if (!parent.length) {
 							// focus is outside the control; close menu
 							player.hideSourcechooserSelector();
@@ -109,7 +115,11 @@
 				.on('click', 'input[type=radio]', function () {
 					// set aria states
 					$(this).attr('aria-selected', true).attr('checked', 'checked');
-					$(this).closest('.mejs-sourcechooser-selector').find('input[type=radio]').not(this).attr('aria-selected', 'false').removeAttr('checked');
+					$(this).closest('.' + t.options.classPrefix + 'sourcechooser-selector')
+						.find('input[type=radio]')
+						.not(this)
+						.attr('aria-selected', 'false')
+						.removeAttr('checked');
 
 					var src = this.value;
 
@@ -137,9 +147,10 @@
 
 				// Handle click so that screen readers can toggle the menu
 				.on('click', 'button', function (e) {
-					if ($(this).siblings('.mejs-sourcechooser-selector').hasClass('mejs-offscreen')) {
+					if ($(this).siblings('.' + t.options.classPrefix + 'sourcechooser-selector').hasClass(t.options.classPrefix + 'offscreen')) {
 						player.showSourcechooserSelector();
-						$(this).siblings('.mejs-sourcechooser-selector').find('input[type=radio]:checked').first().focus();
+						$(this).siblings('.' + t.options.classPrefix + 'sourcechooser-selector')
+							.find('input[type=radio]:checked').first().focus();
 					} else {
 						player.hideSourcechooserSelector();
 					}
@@ -170,9 +181,13 @@
 
 			t.sourcechooserButton.find('ul').append(
 				$('<li>' +
-					'<input type="radio" name="' + t.id + '_sourcechooser" id="' + t.id + '_sourcechooser_' + label + type + '" role="menuitemradio" value="' + src + '" ' + (isCurrent ? 'checked="checked"' : '') + 'aria-selected="' + isCurrent + '"' + ' />' +
-					'<label for="' + t.id + '_sourcechooser_' + label + type + '" aria-hidden="true">' + label + ' (' + type + ')</label>' +
-					'</li>')
+					'<input type="radio" name="' + t.id + '_sourcechooser" ' +
+						'id="' + t.id + '_sourcechooser_' + label + type + '" ' +
+						'role="menuitemradio" value="' + src + '" ' + (isCurrent ? 'checked="checked"' : '') +
+						'aria-selected="' + isCurrent + '"' + ' />' +
+					'<label for="' + t.id + '_sourcechooser_' + label + type + '" ' +
+						'aria-hidden="true">' + label + ' (' + type + ')</label>' +
+				'</li>')
 			);
 
 			t.adjustSourcechooserBox();
@@ -185,8 +200,8 @@
 		adjustSourcechooserBox: function () {
 			var t = this;
 			// adjust the size of the outer box
-			t.sourcechooserButton.find('.mejs-sourcechooser-selector').height(
-				t.sourcechooserButton.find('.mejs-sourcechooser-selector ul').outerHeight(true)
+			t.sourcechooserButton.find('.' + t.options.classPrefix + 'sourcechooser-selector').height(
+				t.sourcechooserButton.find('.' + t.options.classPrefix + 'sourcechooser-selector ul').outerHeight(true)
 			);
 		},
 
@@ -197,12 +212,13 @@
 
 			var t = this;
 
-			if (t.sourcechooserButton === undefined || !t.sourcechooserButton.find('.mejs-sourcechooser-selector').find('input[type=radio]').length) {
+			if (t.sourcechooserButton === undefined ||
+				!t.sourcechooserButton.find('.' + t.options.classPrefix + 'sourcechooser-selector').find('input[type=radio]').length) {
 				return;
 			}
 
-			this.sourcechooserButton.find('.mejs-sourcechooser-selector')
-			.addClass('mejs-offscreen')
+			this.sourcechooserButton.find('.' + t.options.classPrefix + 'sourcechooser-selector')
+			.addClass(t.options.classPrefix + 'offscreen')
 			.attr('aria-expanded', 'false')
 			.attr('aria-hidden', 'true')
 			.find('input[type=radio]') // make radios not focusable
@@ -216,12 +232,13 @@
 
 			var t = this;
 
-			if (t.sourcechooserButton === undefined || !t.sourcechooserButton.find('.mejs-sourcechooser-selector').find('input[type=radio]').length) {
+			if (t.sourcechooserButton === undefined ||
+				!t.sourcechooserButton.find('.' + t.options.classPrefix + 'sourcechooser-selector').find('input[type=radio]').length) {
 				return;
 			}
 
-			this.sourcechooserButton.find('.mejs-sourcechooser-selector')
-			.removeClass('mejs-offscreen')
+			this.sourcechooserButton.find('.' + t.options.classPrefix + 'sourcechooser-selector')
+			.removeClass(t.options.classPrefix + 'offscreen')
 			.attr('aria-expanded', 'true')
 			.attr('aria-hidden', 'false')
 			.find('input[type=radio]')

--- a/src/js/mediaelementplayer-feature-speed.js
+++ b/src/js/mediaelementplayer-feature-speed.js
@@ -97,10 +97,13 @@
 
 			t.clearspeed(player);
 
-			player.speedButton = $('<div class="mejs-button mejs-speed-button">' +
-						'<button type="button" aria-controls="' + t.id + '" title="' + speedTitle + '" aria-label="' + speedTitle + '">' + getSpeedNameFromValue(t.options.defaultSpeed) + '</button>' +
-						'<div class="mejs-speed-selector mejs-offscreen">' +
-							'<ul class="mejs-speed-selector-list"></ul>' +
+			player.speedButton = $('<div class="' + t.options.classPrefix + 'button ' +
+			                                        t.options.classPrefix + 'speed-button">' +
+						'<button type="button" aria-controls="' + t.id + '" title="' + speedTitle + '" ' +
+							'aria-label="' + speedTitle + '">' + getSpeedNameFromValue(t.options.defaultSpeed) + '</button>' +
+						'<div class="' + t.options.classPrefix + 'speed-selector ' +
+						                 t.options.classPrefix + 'offscreen">' +
+							'<ul class="' + t.options.classPrefix + 'speed-selector-list"></ul>' +
 						'</div>' +
 					'</div>')
 						.appendTo(controls);
@@ -110,15 +113,15 @@
 				inputId = t.id + '-speed-' + speeds[i].value;
 
 				player.speedButton.find('ul').append(
-					$('<li class="mejs-speed-selector-list-item">' +
-						'<input class="mejs-speed-selector-input" ' +
+					$('<li class="' + t.options.classPrefix + 'speed-selector-list-item">' +
+						'<input class="' + t.options.classPrefix + 'speed-selector-input" ' +
 							'type="radio" name="' + t.id + '_speed" disabled="disabled"' +
 							'value="' + speeds[i].value + '" ' +
 							'id="' + inputId + '" ' +
 							(speeds[i].value === t.options.defaultSpeed ? ' checked="checked"' : '') +
 						' />' +
-						'<label class="mejs-speed-selector-label' +
-						(speeds[i].value === t.options.defaultSpeed ? ' mejs-speed-selected' : '') +
+						'<label class="' + t.options.classPrefix + 'speed-selector-label' +
+						(speeds[i].value === t.options.defaultSpeed ? ' ' + t.options.classPrefix + 'speed-selected' : '') +
 						'">' + speeds[i].name + '</label>' +
 					'</li>')
 				);
@@ -131,18 +134,18 @@
 				$(this).prop('disabled', false);
 			});
 
-			player.speedSelector = player.speedButton.find('.mejs-speed-selector');
+			player.speedSelector = player.speedButton.find('.' + t.options.classPrefix + 'speed-selector');
 
 			// hover or keyboard focus
 			player.speedButton
 				.on('mouseenter focusin', function(e) {
-					player.speedSelector.removeClass('mejs-offscreen')
+					player.speedSelector.removeClass(t.options.classPrefix + 'offscreen')
 						.height(player.speedSelector.find('ul').outerHeight(true))
 						.css('top', (-1 * player.speedSelector.height()) + 'px')
 					;
 				})
 				.on('mouseleave focusout', function(e) {
-					player.speedSelector.addClass("mejs-offscreen");
+					player.speedSelector.addClass(t.options.classPrefix + "offscreen");
 				})
 				// handle clicks to the language radio buttons
 				.on('click','input[type=radio]',function() {
@@ -156,15 +159,17 @@
 					player.speedButton
 						.find('button').html(getSpeedNameFromValue(newSpeed))
 						.end()
-						.find('.mejs-speed-selected').removeClass('mejs-speed-selected')
+						.find('.' + t.options.classPrefix + 'speed-selected')
+						.removeClass(t.options.classPrefix + 'speed-selected')
 						.end()
 						.find('input[type="radio"]')
 					;
 
 					self.prop('checked', true)
-						.siblings('.mejs-speed-selector-label').addClass('mejs-speed-selected');
+						.siblings('.' + t.options.classPrefix + 'speed-selector-label')
+						.addClass(t.options.classPrefix + 'speed-selected');
 				})
-				.on('click','.mejs-speed-selector-label',function() {
+				.on('click', '.' + t.options.classPrefix + 'speed-selector-label',function() {
 					$(this).siblings('input[type="radio"]').trigger('click');
 				})
 				//Allow up/down arrow to change the selected radio without changing the volume.

--- a/src/js/mediaelementplayer-feature-stop.js
+++ b/src/js/mediaelementplayer-feature-stop.js
@@ -30,8 +30,12 @@
 				t = this,
 				stopTitle = t.options.stopText ? t.options.stopText : mejs.i18n.t('mejs.stop');
 
-			$('<div class="mejs-button mejs-stop-button mejs-stop">' +
-				'<button type="button" aria-controls="' + t.id + '" title="' + stopTitle + '" aria-label="' + stopTitle + '"></button>' +
+			$('<div class="' +  t.options.classPrefix + 'button ' +
+			                    t.options.classPrefix + 'stop-button ' +
+			                    t.options.classPrefix + 'stop">' +
+					'<button type="button" aria-controls="' + t.id + '" ' +
+						'title="' + stopTitle + '" aria-label="' + stopTitle + '">' +
+					'</button>' +
 				'</div>')
 			.appendTo(controls)
 			.click(function () {
@@ -41,11 +45,16 @@
 				if (media.currentTime > 0) {
 					media.setCurrentTime(0);
 					media.pause();
-					controls.find('.mejs-time-current').width('0px');
-					controls.find('.mejs-time-handle').css('left', '0px');
-					controls.find('.mejs-time-float-current').html(mejs.Utility.secondsToTimeCode(0, player.options.alwaysShowHours));
-					controls.find('.mejs-currenttime').html(mejs.Utility.secondsToTimeCode(0, player.options.alwaysShowHours));
-					layers.find('.mejs-poster').show();
+					controls.find('.' +  t.options.classPrefix + 'time-current')
+						.width('0px');
+					controls.find('.' +  t.options.classPrefix + 'time-handle')
+						.css('left', '0px');
+					controls.find('.' +  t.options.classPrefix + 'time-float-current')
+						.html(mejs.Utility.secondsToTimeCode(0, player.options.alwaysShowHours));
+					controls.find('.' +  t.options.classPrefix + 'currenttime')
+						.html(mejs.Utility.secondsToTimeCode(0, player.options.alwaysShowHours));
+					layers.find('.' +  t.options.classPrefix + 'poster')
+						.show();
 				}
 			});
 		}

--- a/src/js/mediaelementplayer-feature-time.js
+++ b/src/js/mediaelementplayer-feature-time.js
@@ -33,14 +33,14 @@
 		buildcurrent: function(player, controls, layers, media) {
 			var t = this;
 
-			$('<div class="mejs-time" role="timer" aria-live="off">' +
-					'<span class="mejs-currenttime">' +
+			$('<div class="' + t.options.classPrefix + 'time" role="timer" aria-live="off">' +
+					'<span class="' + t.options.classPrefix + 'currenttime">' +
 						mejs.Utility.secondsToTimeCode(0, player.options.alwaysShowHours) +
                     '</span>'+
 				'</div>')
 			.appendTo(controls);
 
-			t.currenttime = t.controls.find('.mejs-currenttime');
+			t.currenttime = t.controls.find('.' + t.options.classPrefix + 'currenttime');
 
 			media.addEventListener('timeupdate',function() {
 				if (t.controlsAreVisible) {
@@ -62,26 +62,28 @@
 		buildduration: function(player, controls, layers, media) {
 			var t = this;
 
-			if (controls.children().last().find('.mejs-currenttime').length > 0) {
+			if (controls.children().last().find('.' + t.options.classPrefix + 'currenttime').length > 0) {
 				$(t.options.timeAndDurationSeparator +
-					'<span class="mejs-duration">' +
+					'<span class="' + t.options.classPrefix + 'duration">' +
 						mejs.Utility.secondsToTimeCode(t.options.duration, t.options.alwaysShowHours) +
 					'</span>')
-					.appendTo(controls.find('.mejs-time'));
+					.appendTo(controls.find('.' + t.options.classPrefix + 'time'));
 			} else {
 
 				// add class to current time
-				controls.find('.mejs-currenttime').parent().addClass('mejs-currenttime-container');
+				controls.find('.' + t.options.classPrefix + 'currenttime').parent()
+					.addClass(t.options.classPrefix + 'currenttime-container');
 
-				$('<div class="mejs-time mejs-duration-container">'+
-					'<span class="mejs-duration">' +
+				$('<div class="' + t.options.classPrefix + 'time ' +
+				                   t.options.classPrefix + 'duration-container">'+
+					'<span class="' + t.options.classPrefix + 'duration">' +
 						mejs.Utility.secondsToTimeCode(t.options.duration, t.options.alwaysShowHours) +
 					'</span>' +
 				'</div>')
 				.appendTo(controls);
 			}
 
-			t.durationD = t.controls.find('.mejs-duration');
+			t.durationD = t.controls.find('.' + t.options.classPrefix + 'duration');
 
 			media.addEventListener('timeupdate',function() {
 				if (t.controlsAreVisible) {
@@ -126,7 +128,7 @@
 			}
 
 			//Toggle the long video class if the video is longer than an hour.
-			t.container.toggleClass("mejs-long-video", duration > 3600);
+			t.container.toggleClass(t.options.classPrefix + "long-video", duration > 3600);
 
 			if (t.durationD && duration > 0) {
 				t.durationD.html(mejs.Utility.secondsToTimeCode(duration, t.options.alwaysShowHours));

--- a/src/js/mediaelementplayer-feature-tracks.js
+++ b/src/js/mediaelementplayer-feature-tracks.js
@@ -78,21 +78,34 @@
 
 			t.cleartracks(player);
 			player.chapters =
-					$('<div class="mejs-chapters mejs-layer"></div>')
+					$('<div class="' + t.options.classPrefix + 'chapters ' +
+					                   t.options.classPrefix + 'layer"></div>')
 						.prependTo(layers).hide();
 			player.captions =
-					$('<div class="mejs-captions-layer mejs-layer"><div class="mejs-captions-position mejs-captions-position-hover" ' +
-					attr + '><span class="mejs-captions-text"></span></div></div>')
+					$('<div class="' + t.options.classPrefix + 'captions-layer ' +
+					                   t.options.classPrefix + 'layer">' +
+						'<div class="' + t.options.classPrefix + 'captions-position ' +
+						                 t.options.classPrefix + 'captions-position-hover" ' +
+							attr + '>' +
+								'<span class="' + t.options.classPrefix + 'captions-text"></span></div></div>')
 						.prependTo(layers).hide();
-			player.captionsText = player.captions.find('.mejs-captions-text');
+			player.captionsText = player.captions.find('.' + t.options.classPrefix + 'captions-text');
 			player.captionsButton =
-					$('<div class="mejs-button mejs-captions-button">' +
-						'<button type="button" aria-controls="' + t.id + '" title="' + tracksTitle + '" aria-label="' + tracksTitle + '"></button>' +
-						'<div class="mejs-captions-selector mejs-offscreen">' +
-							'<ul class="mejs-captions-selector-list">'+
-								'<li class="mejs-captions-selector-list-item">'+
-									'<input type="radio" class="mejs-captions-selector-input" name="' + player.id + '_captions" id="' + player.id + '_captions_none" value="none" checked="checked" />' +
-									'<label class="mejs-captions-selector-label mejs-captions-selected" for="' + player.id + '_captions_none">' + mejs.i18n.t('mejs.none') + '</label>' +
+					$('<div class="' + t.options.classPrefix + 'button ' +
+					                   t.options.classPrefix + 'captions-button">' +
+						'<button type="button" aria-controls="' + t.id + '" title="' + tracksTitle + '" ' +
+							'aria-label="' + tracksTitle + '"></button>' +
+						'<div class="' + t.options.classPrefix + 'captions-selector ' +
+						                 t.options.classPrefix + 'offscreen">' +
+							'<ul class="' + t.options.classPrefix + 'captions-selector-list">'+
+								'<li class="' + t.options.classPrefix + 'captions-selector-list-item">'+
+									'<input type="radio" class="' + t.options.classPrefix + 'captions-selector-input" ' +
+										'name="' + player.id + '_captions" id="' + player.id + '_captions_none" ' +
+										'value="none" checked="checked" />' +
+									'<label class="' + t.options.classPrefix + 'captions-selector-label ' +
+									                   t.options.classPrefix + 'captions-selected" ' +
+										'for="' + player.id + '_captions_none">' + mejs.i18n.t('mejs.none') +
+									'</label>' +
 								'</li>'	+
 							'</ul>' +
 						'</div>' +
@@ -123,17 +136,19 @@
 				// hover or keyboard focus
 				player.captionsButton
 					.on('mouseenter focusin', function() {
-						$(this).find('.mejs-captions-selector').removeClass('mejs-offscreen');
+						$(this).find('.' + t.options.classPrefix + 'captions-selector')
+							.removeClass(t.options.classPrefix + 'offscreen');
 					})
 					.on('mouseleave focusout', function() {
-						$(this).find(".mejs-captions-selector").addClass("mejs-offscreen");
+						$(this).find('.' + t.options.classPrefix + 'captions-selector')
+							.addClass(t.options.classPrefix + 'offscreen');
 					})
 					// handle clicks to the language radio buttons
 					.on('click','input[type=radio]',function() {
 						lang = this.value;
 						player.setTrack(lang);
 					})
-					.on('click','.mejs-captions-selector-label',function() {
+					.on('click', '.' + t.options.classPrefix + 'captions-selector-label', function() {
 						$(this).siblings('input[type="radio"]').trigger('click');
 					})
 					//Allow up/down arrow to change the selected radio without changing the volume.
@@ -147,17 +162,20 @@
 				player.container
 					.on('controlsshown', function () {
 						// push captions above controls
-						player.container.find('.mejs-captions-position').addClass('mejs-captions-position-hover');
+						player.container.find('.' + t.options.classPrefix + 'captions-position')
+							.addClass(t.options.classPrefix + 'captions-position-hover');
 
 					})
 					.on('controlshidden', function () {
 						if (!media.paused) {
 							// move back to normal place
-							player.container.find('.mejs-captions-position').removeClass('mejs-captions-position-hover');
+							player.container.find('.' + t.options.classPrefix + 'captions-position')
+								.removeClass(t.options.classPrefix + 'captions-position-hover');
 						}
 					});
 			} else {
-				player.container.find('.mejs-captions-position').addClass('mejs-captions-position-hover');
+				player.container.find('.' + t.options.classPrefix + 'captions-position')
+					.addClass(t.options.classPrefix + 'captions-position-hover');
 			}
 
 			player.trackToLoad = -1;
@@ -198,14 +216,15 @@
 				function () {
 					// chapters
 					if (player.hasChapters) {
-						player.chapters.removeClass('mejs-offscreen');
-						player.chapters.fadeIn(200).height(player.chapters.find('.mejs-chapter').outerHeight());
+						player.chapters.removeClass(t.options.classPrefix + 'offscreen');
+						player.chapters.fadeIn(200)
+							.height(player.chapters.find('.' + t.options.classPrefix + 'chapter').outerHeight());
 					}
 				},
 				function () {
 					if (player.hasChapters && !media.paused) {
 						player.chapters.fadeOut(200, function() {
-							$(this).addClass('mejs-offscreen');
+							$(this).addClass(t.options.classPrefix + 'offscreen');
 							$(this).css('display','block');
 						});
 					}
@@ -217,7 +236,7 @@
 
 			// check for autoplay
 			if (player.node.getAttribute('autoplay') !== null) {
-				player.chapters.addClass('mejs-offscreen');
+				player.chapters.addClass(t.options.classPrefix + 'offscreen');
 			}
 		},
 
@@ -258,20 +277,22 @@
 			t.captionsButton
 				.find('input[type="radio"]').prop('checked', false)
 				.end()
-				.find('.mejs-captions-selected').removeClass('mejs-captions-selected')
+				.find('.' + t.options.classPrefix + 'captions-selected')
+				.removeClass(t.options.classPrefix + 'captions-selected')
 				.end()
 				.find('input[value="' + lang + '"]').prop('checked', true)
-				.siblings('.mejs-captions-selector-label').addClass('mejs-captions-selected')
+				.siblings('.' + t.options.classPrefix + 'captions-selector-label')
+				.addClass(t.options.classPrefix + 'captions-selected')
 			;
 
 			if (lang === 'none') {
 				t.selectedTrack = null;
-				t.captionsButton.removeClass('mejs-captions-enabled');
+				t.captionsButton.removeClass(t.options.classPrefix + 'captions-enabled');
 			} else {
 				for (i=0; i<t.tracks.length; i++) {
 					if (t.tracks[i].srclang === lang) {
 						if (t.selectedTrack === null)
-							t.captionsButton.addClass('mejs-captions-enabled');
+							t.captionsButton.addClass(t.options.classPrefix + 'captions-enabled');
 						t.selectedTrack = t.tracks[i];
 						t.captions.attr('lang', t.selectedTrack.srclang);
 						t.displayCaptions();
@@ -367,7 +388,7 @@
 
 			t.captionsButton
 				.find('input[value=' + lang + ']').prop('disabled',false)
-				.siblings('.mejs-captions-selector-label').html(label);
+				.siblings('.' + t.options.classPrefix + 'captions-selector-label').html(label);
 
 			// auto select
 			if (t.options.startLanguage === lang) {
@@ -401,16 +422,18 @@
 			}
 
 			t.captionsButton.find('ul').append(
-				$('<li class="mejs-captions-selector-list-item">'+
-					'<input type="radio" class="mejs-captions-selector-input" name="' + t.id + '_captions" id="' + t.id + '_captions_' + lang + '" value="' + lang + '" disabled="disabled" />' +
-					'<label class="mejs-captions-selector-label">' + label + ' (loading)' + '</label>' +
+				$('<li class="' + t.options.classPrefix + 'captions-selector-list-item">' +
+					'<input type="radio" class="' + t.options.classPrefix + 'captions-selector-input" ' +
+						'name="' + t.id + '_captions" id="' + t.id + '_captions_' + lang + '" ' +
+						'value="' + lang + '" disabled="disabled" />' +
+					'<label class="' + t.options.classPrefix + 'captions-selector-label">' + label + ' (loading)' + '</label>' +
 				'</li>')
 			);
 
 			t.adjustLanguageBox();
 
 			// remove this from the dropdownlist (if it exists)
-			t.container.find('.mejs-captions-translations option[value=' + lang + ']').remove();
+			t.container.find('.' + t.options.classPrefix + 'captions-translations option[value=' + lang + ']').remove();
 		},
 
 		/**
@@ -419,9 +442,9 @@
 		adjustLanguageBox:function() {
 			var t = this;
 			// adjust the size of the outer box
-			t.captionsButton.find('.mejs-captions-selector').height(
-				t.captionsButton.find('.mejs-captions-selector-list').outerHeight(true) +
-				t.captionsButton.find('.mejs-captions-translations').outerHeight(true)
+			t.captionsButton.find('.' + t.options.classPrefix + 'captions-selector').height(
+				t.captionsButton.find('.' + t.options.classPrefix + 'captions-selector-list').outerHeight(true) +
+				t.captionsButton.find('.' + t.options.classPrefix + 'captions-translations').outerHeight(true)
 			);
 		},
 
@@ -469,7 +492,8 @@
 				for (i=0; i<track.entries.times.length; i++) {
 					if (t.media.currentTime >= track.entries.times[i].start && t.media.currentTime <= track.entries.times[i].stop) {
 						// Set the line before the timecode as a class so the cue can be targeted if needed
-						t.captionsText.html(track.entries.text[i]).attr('class', 'mejs-captions-text ' + (track.entries.times[i].identifier || ''));
+						t.captionsText.html(track.entries.text[i])
+							.attr('class', t.options.classPrefix + 'captions-text ' + (track.entries.times[i].identifier || ''));
 						t.captions.show().height(0);
 						return; // exit out if one is visible;
 					}
@@ -602,16 +626,23 @@
 				//}
 
 				t.chapters.append( $(
-					'<div class="mejs-chapter" rel="' + chapters.entries.times[i].start + '" style="left: ' + usedPercent.toString() + '%;width: ' + percent.toString() + '%;">' +
-						'<div class="mejs-chapter-block' + ((i==chapters.entries.times.length-1) ? ' mejs-chapter-block-last' : '') + '">' +
+					'<div class="' +  t.options.classPrefix + 'chapter" ' +
+						'rel="' + chapters.entries.times[i].start + '" ' +
+						'style="left: ' + usedPercent.toString() + '%; width: ' + percent.toString() + '%;">' +
+						'<div class="' +  t.options.classPrefix + 'chapter-block' +
+							((i === chapters.entries.times.length - 1) ? ' ' +  t.options.classPrefix + 'chapter-block-last' : '') + '">' +
 							'<span class="ch-title">' + chapters.entries.text[i] + '</span>' +
-							'<span class="ch-time">' + mejs.Utility.secondsToTimeCode(chapters.entries.times[i].start, t.options.alwaysShowHours) + '&ndash;' + mejs.Utility.secondsToTimeCode(chapters.entries.times[i].stop, t.options.alwaysShowHours) + '</span>' +
+							'<span class="ch-time">' +
+								mejs.Utility.secondsToTimeCode(chapters.entries.times[i].start, t.options.alwaysShowHours) +
+								'&ndash;' +
+								mejs.Utility.secondsToTimeCode(chapters.entries.times[i].stop, t.options.alwaysShowHours) +
+							'</span>' +
 						'</div>' +
 					'</div>'));
 				usedPercent += percent;
 			}
 
-			t.chapters.find('div.mejs-chapter').click(function() {
+			t.chapters.find('.' +  t.options.classPrefix + 'chapter').click(function() {
 				t.media.setCurrentTime( parseFloat( $(this).attr('rel') ) );
 				if (t.media.paused) {
 					t.media.play();

--- a/src/js/mediaelementplayer-feature-volume.js
+++ b/src/js/mediaelementplayer-feature-volume.js
@@ -53,41 +53,53 @@
 				mute = (mode === 'horizontal') ?
 
 					// horizontal version
-					$('<div class="mejs-button mejs-volume-button mejs-mute">' +
-						'<button type="button" aria-controls="' + t.id +
-						'" title="' + t.options.muteText +
-						'" aria-label="' + t.options.muteText +
+					$('<div class="' +  t.options.classPrefix + 'button ' +
+					                    t.options.classPrefix + 'volume-button' +
+					                    t.options.classPrefix + 'mute">' +
+						'<button type="button" aria-controls="' + t.id + '" ' +
+							'title="' + t.options.muteText + '" ' +
+							'aria-label="' + t.options.muteText +
 						'"></button>' +
 						'</div>' +
-						'<a href="javascript:void(0);" class="mejs-horizontal-volume-slider">' + // outer background
-						'<span class="mejs-offscreen">' + t.options.allyVolumeControlText + '</span>' +
-						'<div class="mejs-horizontal-volume-total">' + // line background
-							'<div class="mejs-horizontal-volume-current"></div>' + // current volume
-							'<div class="mejs-horizontal-volume-handle"></div>' + // handle
-						'</div>' +
+						'<a href="javascript:void(0);" class="' +  t.options.classPrefix + 'horizontal-volume-slider">' + // outer background
+							'<span class="' +  t.options.classPrefix + 'offscreen">' +
+								t.options.allyVolumeControlText +
+							'</span>' +
+							'<div class="' +  t.options.classPrefix + 'horizontal-volume-total">' + // line background
+								'<div class="' +  t.options.classPrefix + 'horizontal-volume-current"></div>' + // current volume
+								'<div class="' +  t.options.classPrefix + 'horizontal-volume-handle"></div>' + // handle
+							'</div>' +
 						'</a>'
 					)
 					.appendTo(controls) :
 
 					// vertical version
-					$('<div class="mejs-button mejs-volume-button mejs-mute">' +
+					$('<div class="' +  t.options.classPrefix + 'button ' +
+					                    t.options.classPrefix + 'volume-button ' +
+					                    t.options.classPrefix + 'mute">' +
 						'<button type="button" aria-controls="' + t.id +
 						'" title="' + t.options.muteText +
 						'" aria-label="' + t.options.muteText +
 						'"></button>' +
-						'<a href="javascript:void(0);" class="mejs-volume-slider">' + // outer background
-						'<span class="mejs-offscreen">' + t.options.allyVolumeControlText + '</span>' +
-						'<div class="mejs-volume-total">' + // line background
-							'<div class="mejs-volume-current"></div>' + // current volume
-							'<div class="mejs-volume-handle"></div>' + // handle
-						'</div>' +
+						'<a href="javascript:void(0);" class="' +  t.options.classPrefix + 'volume-slider">' + // outer background
+							'<span class="' +  t.options.classPrefix + 'offscreen">' +
+								t.options.allyVolumeControlText +
+							'</span>' +
+							'<div class="' +  t.options.classPrefix + 'volume-total">' + // line background
+								'<div class="' +  t.options.classPrefix + 'volume-current"></div>' + // current volume
+								'<div class="' +  t.options.classPrefix + 'volume-handle"></div>' + // handle
+							'</div>' +
 						'</a>' +
 						'</div>')
 					.appendTo(controls),
-				volumeSlider = t.container.find('.mejs-volume-slider, .mejs-horizontal-volume-slider'),
-				volumeTotal = t.container.find('.mejs-volume-total, .mejs-horizontal-volume-total'),
-				volumeCurrent = t.container.find('.mejs-volume-current, .mejs-horizontal-volume-current'),
-				volumeHandle = t.container.find('.mejs-volume-handle, .mejs-horizontal-volume-handle'),
+				volumeSlider = t.container.find('.' +  t.options.classPrefix + 'volume-slider, ' +
+				                                '.' +  t.options.classPrefix + 'horizontal-volume-slider'),
+				volumeTotal = t.container.find('.' + t.options.classPrefix + 'volume-total, ' +
+				                               '.' + t.options.classPrefix + 'horizontal-volume-total'),
+				volumeCurrent = t.container.find('.' +  t.options.classPrefix + 'volume-current, ' +
+				                                 '.' +  t.options.classPrefix + 'horizontal-volume-current'),
+				volumeHandle = t.container.find('.' +  t.options.classPrefix + 'volume-handle, ' +
+				                                '.' +  t.options.classPrefix + 'horizontal-volume-handle'),
 
 				/**
 				 * @private
@@ -101,11 +113,17 @@
 
 					// adjust mute button style
 					if (volume === 0) {
-						mute.removeClass('mejs-mute').addClass('mejs-unmute');
-						mute.children('button').attr('title', mejs.i18n.t('mejs.unmute')).attr('aria-label', mejs.i18n.t('mejs.unmute'));
+						mute.removeClass(t.options.classPrefix + 'mute')
+							.addClass(t.options.classPrefix + 'unmute');
+						mute.children('button')
+							.attr('title', mejs.i18n.t('mejs.unmute'))
+							.attr('aria-label', mejs.i18n.t('mejs.unmute'));
 					} else {
-						mute.removeClass('mejs-unmute').addClass('mejs-mute');
-						mute.children('button').attr('title', mejs.i18n.t('mejs.mute')).attr('aria-label', mejs.i18n.t('mejs.mute'));
+						mute.removeClass( t.options.classPrefix + 'unmute')
+							.addClass( t.options.classPrefix + 'mute');
+						mute.children('button')
+							.attr('title', mejs.i18n.t('mejs.mute'))
+							.attr('aria-label', mejs.i18n.t('mejs.mute'));
 					}
 
 					var volumePercentage = volume * 100 + '%';
@@ -270,11 +288,11 @@
 
 			//Keyboard input
 			mute.find('button').on('focus', function () {
-				if (!volumeSlider.hasClass('mejs-horizontal-volume-slider')) {
+				if (!volumeSlider.hasClass(t.options.classPrefix + 'horizontal-volume-slider')) {
 					volumeSlider.show();
 				}
 			}).on('blur', function () {
-				if (!volumeSlider.hasClass('mejs-horizontal-volume-slider')) {
+				if (!volumeSlider.hasClass(t.options.classPrefix + 'horizontal-volume-slider')) {
 					volumeSlider.hide();
 				}
 			});
@@ -284,10 +302,12 @@
 				if (!mouseIsDown) {
 					if (media.muted) {
 						positionVolumeHandle(0);
-						mute.removeClass('mejs-mute').addClass('mejs-unmute');
+						mute.removeClass(t.options.classPrefix + 'mute')
+							.addClass(t.options.classPrefix + 'unmute');
 					} else {
 						positionVolumeHandle(media.volume);
-						mute.removeClass('mejs-unmute').addClass('mejs-mute');
+						mute.removeClass(t.options.classPrefix + 'unmute')
+							.addClass(t.options.classPrefix + 'mute');
 					}
 				}
 				updateVolumeSlider(e);
@@ -308,10 +328,12 @@
 			t.container.on('controlsresize', function () {
 				if (media.muted) {
 					positionVolumeHandle(0);
-					mute.removeClass('mejs-mute').addClass('mejs-unmute');
+					mute.removeClass(t.options.classPrefix + 'mute')
+						.addClass(t.options.classPrefix + 'unmute');
 				} else {
 					positionVolumeHandle(media.volume);
-					mute.removeClass('mejs-unmute').addClass('mejs-mute');
+					mute.removeClass(t.options.classPrefix + 'unmute')
+						.addClass(t.options.classPrefix + 'mute');
 				}
 			});
 		}

--- a/src/js/mediaelementplayer-player.js
+++ b/src/js/mediaelementplayer-player.js
@@ -86,6 +86,8 @@
 		isVideo: true,
 		// stretching modes (auto, fill, responsive, none)
 		stretching: 'auto',
+		// prefix class names on elements
+		classPrefix: 'mejs__',
 		// turns keyboard support on and off for this instance
 		enableKeyboard: true,
 		// when this player starts, it will pause other players
@@ -112,9 +114,9 @@
 				keys: [38], // UP
 				action: function (player, media, key, event) {
 
-					if (player.container.find('.mejs-volume-button>button').is(':focus') ||
-						player.container.find('.mejs-volume-slider').is(':focus')) {
-						player.container.find('.mejs-volume-slider').css('display', 'block');
+					if (player.container.find('.' + t.options.classPrefix + 'volume-button>button').is(':focus') ||
+						player.container.find('.' + t.options.classPrefix + 'volume-slider').is(':focus')) {
+						player.container.find('.' + t.options.classPrefix + 'volume-slider').css('display', 'block');
 					}
 					if (player.isVideo) {
 						player.showControls();
@@ -132,9 +134,9 @@
 			{
 				keys: [40], // DOWN
 				action: function (player, media, key, event) {
-					if (player.container.find('.mejs-volume-button>button').is(':focus') ||
-						player.container.find('.mejs-volume-slider').is(':focus')) {
-						player.container.find('.mejs-volume-slider').css('display', 'block');
+					if (player.container.find('.' + t.options.classPrefix + 'volume-button>button').is(':focus') ||
+						player.container.find('.' + t.options.classPrefix + 'volume-slider').is(':focus')) {
+						player.container.find('.' + t.options.classPrefix + 'volume-slider').css('display', 'block');
 					}
 
 					if (player.isVideo) {
@@ -204,7 +206,7 @@
 			{
 				keys: [77], // M
 				action: function (player, media, key, event) {
-					player.container.find('.mejs-volume-slider').css('display', 'block');
+					player.container.find('.' + t.options.classPrefix + 'volume-slider').css('display', 'block');
 					if (player.isVideo) {
 						player.showControls();
 						player.startControlsTimer();
@@ -417,16 +419,19 @@
 				var videoPlayerTitle = t.isVideo ?
 					mejs.i18n.t('mejs.video-player') : mejs.i18n.t('mejs.audio-player');
 				// insert description for screen readers
-				$('<span class="mejs-offscreen">' + videoPlayerTitle + '</span>').insertBefore(t.$media);
+				$('<span class="' + t.options.classPrefix + 'offscreen">' + videoPlayerTitle + '</span>').insertBefore(t.$media);
 				// build container
 				t.container =
-					$('<div id="' + t.id + '" class="mejs-container mejs-container-keyboard-inactive" ' +
-						'tabindex="0" role="application" aria-label="' + videoPlayerTitle + '">' +
-						'<div class="mejs-inner">' +
-						'<div class="mejs-mediaelement"></div>' +
-						'<div class="mejs-layers"></div>' +
-						'<div class="mejs-controls"></div>' +
-						'<div class="mejs-clear"></div>' +
+					$('<div id="' + t.id + '"' +
+							'class="' + t.options.classPrefix + 'container ' +
+						            	t.options.classPrefix + 'container-keyboard-inactive" ' +
+							'tabindex="0" role="application" ' +
+							'aria-label="' + videoPlayerTitle + '">' +
+						'<div class="' + t.options.classPrefix + 'inner">' +
+						'<div class="' + t.options.classPrefix + 'mediaelement"></div>' +
+						'<div class="' + t.options.classPrefix + 'layers"></div>' +
+						'<div class="' + t.options.classPrefix + 'controls"></div>' +
+						'<div class="' + t.options.classPrefix + 'clear"></div>' +
 						'</div>' +
 						'</div>')
 					.addClass(t.$media[0].className)
@@ -440,10 +445,11 @@
 							if (!t.hasMsNativeFullScreen) {
 								// If e.relatedTarget appears before container, send focus to play button,
 								// else send focus to last control button.
-								var btnSelector = '.mejs-playpause-button > button';
+								var btnSelector = '.' + t.options.classPrefix + 'playpause-button > button';
 
 								if (mejs.Utility.isNodeAfter(e.relatedTarget, t.container[0])) {
-									btnSelector = '.mejs-controls .mejs-button:last-child > button';
+									btnSelector = '.' + t.options.classPrefix + 'controls ' +
+										'.' + t.options.classPrefix + 'button:last-child > button';
 								}
 
 								var button = t.container.find(btnSelector);
@@ -454,34 +460,37 @@
 
 				// When no elements in controls, hide bar completely
 				if (!t.options.features.length) {
-					t.container.css('background', 'transparent').find('.mejs-controls').hide();
+					t.container.css('background', 'transparent')
+						.find('.' + t.options.classPrefix + 'controls')
+						.hide();
 				}
 
-				if (t.isVideo && t.options.stretching === 'fill' && !t.container.parent('mejs-fill-container').length) {
+				if (t.isVideo && t.options.stretching === 'fill' &&
+					!t.container.parent('.' + t.options.classPrefix + 'fill-container').length) {
 					// outer container
 					t.outerContainer = t.$media.parent();
-					t.container.wrap('<div class="mejs-fill-container"/>');
+					t.container.wrap('<div class="' + t.options.classPrefix + 'fill-container"/>');
 				}
 
 				// add classes for user and content
 				t.container.addClass(
-					(mf.isAndroid ? 'mejs-android ' : '') +
-					(mf.isiOS ? 'mejs-ios ' : '') +
-					(mf.isiPad ? 'mejs-ipad ' : '') +
-					(mf.isiPhone ? 'mejs-iphone ' : '') +
-					(t.isVideo ? 'mejs-video ' : 'mejs-audio ')
+					(mf.isAndroid ? t.options.classPrefix + 'android ' : '') +
+					(mf.isiOS ? t.options.classPrefix + '-ios ' : '') +
+					(mf.isiPad ? t.options.classPrefix + '-ipad ' : '') +
+					(mf.isiPhone ? t.options.classPrefix + '-iphone ' : '') +
+					(t.isVideo ? t.options.classPrefix + '-video ' : t.options.classPrefix + 'audio ')
 				);
 
 
 				// move the <video/video> tag into the right spot
-				t.container.find('.mejs-mediaelement').append(t.$media);
+				t.container.find('.' + t.options.classPrefix + 'mediaelement').append(t.$media);
 
 				// needs to be assigned here, after iOS remap
 				t.node.player = t;
 
 				// find parts
-				t.controls = t.container.find('.mejs-controls');
-				t.layers = t.container.find('.mejs-layers');
+				t.controls = t.container.find('.' + t.options.classPrefix + 'controls');
+				t.layers = t.container.find('.' + t.options.classPrefix + 'layers');
 
 				// determine the size
 
@@ -549,27 +558,27 @@
 
 			if (doAnimation) {
 				t.controls
-				.removeClass('mejs-offscreen')
+				.removeClass(t.options.classPrefix + 'offscreen')
 				.stop(true, true).fadeIn(200, function () {
 					t.controlsAreVisible = true;
 					t.container.trigger('controlsshown');
 				});
 
 				// any additional controls people might add and want to hide
-				t.container.find('.mejs-control')
-				.removeClass('mejs-offscreen')
+				t.container.find('.' + t.options.classPrefix + 'control')
+				.removeClass(t.options.classPrefix + 'offscreen')
 				.stop(true, true).fadeIn(200, function () {
 					t.controlsAreVisible = true;
 				});
 
 			} else {
 				t.controls
-				.removeClass('mejs-offscreen')
+				.removeClass(t.options.classPrefix + 'offscreen')
 				.css('display', 'block');
 
 				// any additional controls people might add and want to hide
-				t.container.find('.mejs-control')
-				.removeClass('mejs-offscreen')
+				t.container.find('.' + t.options.classPrefix + 'control')
+				.removeClass(t.options.classPrefix + 'offscreen')
 				.css('display', 'block');
 
 				t.controlsAreVisible = true;
@@ -596,7 +605,7 @@
 				// fade out main controls
 				t.controls.stop(true, true).fadeOut(200, function () {
 					$(this)
-					.addClass('mejs-offscreen')
+					.addClass(t.options.classPrefix + 'offscreen')
 					.css('display', 'block');
 
 					t.controlsAreVisible = false;
@@ -604,21 +613,21 @@
 				});
 
 				// any additional controls people might add and want to hide
-				t.container.find('.mejs-control').stop(true, true).fadeOut(200, function () {
-					$(this)
-					.addClass('mejs-offscreen')
-					.css('display', 'block');
-				});
+				t.container.find('.' + t.options.classPrefix + 'control')
+					.stop(true, true).fadeOut(200, function () {
+						$(this).addClass(t.options.classPrefix + 'offscreen')
+						.css('display', 'block');
+					});
 			} else {
 
 				// hide main controls
 				t.controls
-				.addClass('mejs-offscreen')
+				.addClass(t.options.classPrefix + 'offscreen')
 				.css('display', 'block');
 
 				// hide others
-				t.container.find('.mejs-control')
-				.addClass('mejs-offscreen')
+				t.container.find('.' + t.options.classPrefix + 'control')
+				.addClass(t.options.classPrefix + 'offscreen')
 				.css('display', 'block');
 
 				t.controlsAreVisible = false;
@@ -776,7 +785,8 @@
 
 							if (t.options.clickToPlayPause) {
 								var
-									button = t.$media.closest('.mejs-container').find('.mejs-overlay-button'),
+									button = t.$media.closest('.' + t.options.classPrefix + 'container')
+										.find('.' + t.options.classPrefix + 'overlay-button'),
 									pressed = button.attr('aria-pressed')
 									;
 								if (t.media.paused && pressed) {
@@ -873,7 +883,9 @@
 							t.media.setCurrentTime(0);
 							// Fixing an Android stock browser bug, where "seeked" isn't fired correctly after ending the video and jumping to the beginning
 							window.setTimeout(function () {
-								$(t.container).find('.mejs-overlay-loading').parent().hide();
+								$(t.container)
+									.find('.' + t.options.classPrefix + 'overlay-loading')
+									.parent().hide();
 							}, 20);
 						} catch (exp) {
 
@@ -940,7 +952,7 @@
 				t.container.focusout(function (e) {
 					if (e.relatedTarget) { //FF is working on supporting focusout https://bugzilla.mozilla.org/show_bug.cgi?id=687787
 						var $target = $(e.relatedTarget);
-						if (t.keyboardAction && $target.parents('.mejs-container').length === 0) {
+						if (t.keyboardAction && $target.parents('.' + t.options.classPrefix + 'container').length === 0) {
 							t.keyboardAction = false;
 							if (t.isVideo && !t.options.alwaysShowControls) {
 								t.hideControls(true);
@@ -970,19 +982,21 @@
 
 				// Disable focus outline to improve look-and-feel for regular users
 				t.globalBind('click', function(e) {
-					if ($(e.target).is('.mejs-container')) {
-						$(e.target).addClass('mejs-container-keyboard-inactive');
-					} else if ($(e.target).closest('.mejs-container').length) {
-						$(e.target).closest('.mejs-container').addClass('mejs-container-keyboard-inactive');
+					if ($(e.target).is('.' + t.options.classPrefix + 'container')) {
+						$(e.target).addClass(t.options.classPrefix + 'container-keyboard-inactive');
+					} else if ($(e.target).closest('.' + t.options.classPrefix + 'container').length) {
+						$(e.target).closest('.' + t.options.classPrefix + '-container')
+							.addClass(t.options.classPrefix + 'container-keyboard-inactive');
 					}
 				});
 
 				// Enable focus outline for Accessibility purposes
 				t.globalBind('keydown', function(e) {
-					if ($(e.target).is('.mejs-container')) {
-						$(e.target).removeClass('mejs-container-keyboard-inactive');
-					} else if ($(e.target).closest('.mejs-container').length) {
-						$(e.target).closest('.mejs-container').removeClass('mejs-container-keyboard-inactive');
+					if ($(e.target).is('.' + t.options.classPrefix + '-container')) {
+						$(e.target).removeClass(t.options.classPrefix + 'container-keyboard-inactive');
+					} else if ($(e.target).closest('.' + t.options.classPrefix + 'container').length) {
+						$(e.target).closest('.' + t.options.classPrefix + 'container')
+							.removeClass(t.options.classPrefix + 'container-keyboard-inactive');
 					}
 				});
 
@@ -990,8 +1004,8 @@
 				//	we can't use the play() API for the initial playback on iOS or Android;
 				//	user has to start playback directly by tapping on the iFrame.
 				if (t.media.rendererName !== null && t.media.rendererName.match(/youtube/) && (mf.isiOS || mf.isAndroid)) {
-					t.container.find('.mejs-overlay-play').hide();
-					t.container.find('.mejs-poster').hide();
+					t.container.find('.' + t.options.classPrefix + 'overlay-play').hide();
+					t.container.find('.' + t.options.classPrefix + 'poster').hide();
 				}
 			}
 
@@ -1187,7 +1201,7 @@
 				}
 
 				// set the layers
-				t.layers.children('.mejs-layer')
+				t.layers.children('.' + t.options.classPrefix + 'layer')
 				.width('100%')
 				.height('100%');
 			}
@@ -1235,7 +1249,7 @@
 			t.setDimensions('100%', '100%');
 
 			// This prevents an issue when displaying poster
-			t.container.find('.mejs-poster img').css('display', 'block');
+			t.container.find('.' + t.options.classPrefix + 'poster img').css('display', 'block');
 
 			targetElement = t.container.find('object, embed, iframe, video');
 
@@ -1278,7 +1292,7 @@
 			.width(width)
 			.height(height);
 
-			t.layers.children('.mejs-layer')
+			t.layers.children('.' + t.options.classPrefix + 'layer')
 			.width(width)
 			.height(height);
 		},
@@ -1286,7 +1300,7 @@
 		setControlsSize: function () {
 			var
 				t = this,
-				rail = t.controls.find('.mejs-time-rail')
+				rail = t.controls.find('.' + t.options.classPrefix + 'time-rail')
 			;
 
 			// skip calculation if hidden
@@ -1296,7 +1310,7 @@
 
 			var
 				controlElements = t.controls.children(),
-				margin = parseFloat(controlElements.children('.mejs-time-total').css('margin-left')),
+				margin = parseFloat(controlElements.children('.' + t.options.classPrefix + 'time-total').css('margin-left')),
 				siblingsWidth = 0
 			;
 
@@ -1316,7 +1330,8 @@
 		buildposter: function (player, controls, layers, media) {
 			var t = this,
 				poster =
-					$('<div class="mejs-poster mejs-layer">' +
+					$('<div class="' + t.options.classPrefix + 'poster ' +
+					                   t.options.classPrefix + 'layer">' +
 						'</div>')
 					.appendTo(layers),
 				posterUrl = player.$media.attr('poster');
@@ -1346,11 +1361,12 @@
 
 		setPoster: function (url) {
 			var t = this,
-				posterDiv = t.container.find('.mejs-poster'),
+				posterDiv = t.container.find('.' + t.options.classPrefix + 'poster'),
 				posterImg = posterDiv.find('img');
 
 			if (posterImg.length === 0) {
-				posterImg = $('<img class="mejs-poster-img" width="100%" height="100%" alt="" />').appendTo(posterDiv);
+				posterImg = $('<img class="' + t.options.classPrefix + 'poster-img" width="100%" height="100%" alt="" />')
+					.appendTo(posterDiv);
 			}
 
 			posterImg.attr('src', url);
@@ -1364,30 +1380,37 @@
 
 			var
 				loading =
-					$('<div class="mejs-overlay mejs-layer">' +
-						'<div class="mejs-overlay-loading">' +
-							'<span class="mejs-overlay-loading-bg-img"></span>' +
+					$('<div class="' + t.options.classPrefix + 'overlay ' +
+					                   t.options.classPrefix + 'layer">' +
+						'<div class="' + t.options.classPrefix + 'overlay-loading">' +
+							'<span class="' + t.options.classPrefix + 'overlay-loading-bg-img"></span>' +
 						'</div>' +
 					'</div>')
 					.hide() // start out hidden
 					.appendTo(layers),
 				error =
-					$('<div class="mejs-overlay mejs-layer">' +
-						'<div class="mejs-overlay-error"></div>' +
+					$('<div class="' + t.options.classPrefix + 'overlay ' +
+					                   t.options.classPrefix + 'layer">' +
+						'<div class="' + t.options.classPrefix + 'overlay-error"></div>' +
 						'</div>')
 					.hide() // start out hidden
 					.appendTo(layers),
 				// this needs to come last so it's on top
 				bigPlay =
-					$('<div class="mejs-overlay mejs-layer mejs-overlay-play">' +
-						'<div class="mejs-overlay-button" role="button" aria-label="' + mejs.i18n.t('mejs.play') + '" aria-pressed="false"></div>' +
+					$('<div class="' + t.options.classPrefix + 'overlay ' +
+					                   t.options.classPrefix + 'layer ' +
+									   t.options.classPrefix + 'overlay-play">' +
+						'<div class="' + t.options.classPrefix + 'overlay-button" ' +
+							'role="button" aria-label="' + mejs.i18n.t('mejs.play') +
+							'" aria-pressed="false"></div>' +
 						'</div>')
 					.appendTo(layers)
 					.on('click', function () {	 // Removed 'touchstart' due issues on Samsung Android devices where a tap on bigPlay started and immediately stopped the video
 						if (t.options.clickToPlayPause) {
 
 							var
-								button = t.$media.closest('.mejs-container').find('.mejs-overlay-button'),
+								button = t.$media.closest('.' + t.options.classPrefix + 'container')
+									.find('.' + t.options.classPrefix + 'overlay-button'),
 								pressed = button.attr('aria-pressed')
 							;
 
@@ -1409,25 +1432,25 @@
 			media.addEventListener('play', function () {
 				bigPlay.hide();
 				loading.hide();
-				controls.find('.mejs-time-buffering').hide();
+				controls.find('.' + t.options.classPrefix + 'time-buffering').hide();
 				error.hide();
 			}, false);
 
 			media.addEventListener('playing', function () {
 				bigPlay.hide();
 				loading.hide();
-				controls.find('.mejs-time-buffering').hide();
+				controls.find('.' + t.options.classPrefix + 'time-buffering').hide();
 				error.hide();
 			}, false);
 
 			media.addEventListener('seeking', function () {
 				loading.show();
-				controls.find('.mejs-time-buffering').show();
+				controls.find('.' + t.options.classPrefix + 'time-buffering').show();
 			}, false);
 
 			media.addEventListener('seeked', function () {
 				loading.hide();
-				controls.find('.mejs-time-buffering').hide();
+				controls.find('.' + t.options.classPrefix + 'time-buffering').hide();
 			}, false);
 
 			media.addEventListener('pause', function () {
@@ -1436,7 +1459,7 @@
 
 			media.addEventListener('waiting', function () {
 				loading.show();
-				controls.find('.mejs-time-buffering').show();
+				controls.find('.' + t.options.classPrefix + 'time-buffering').show();
 			}, false);
 
 
@@ -1447,8 +1470,9 @@
 				//	return;
 
 				loading.show();
-				controls.find('.mejs-time-buffering').show();
-				// Firing the 'canplay' event after a timeout which isn't getting fired on some Android 4.1 devices (https://github.com/johndyer/mediaelement/issues/1305)
+				controls.find('.' + t.options.classPrefix + 'time-buffering').show();
+				// Firing the 'canplay' event after a timeout which isn't getting fired on some Android 4.1 devices
+				// (https://github.com/johndyer/mediaelement/issues/1305)
 				if (mejs.MediaFeatures.isAndroid) {
 					media.canplayTimeout = window.setTimeout(
 						function () {
@@ -1463,8 +1487,9 @@
 			}, false);
 			media.addEventListener('canplay', function () {
 				loading.hide();
-				controls.find('.mejs-time-buffering').hide();
-				clearTimeout(media.canplayTimeout); // Clear timeout inside 'loadeddata' to prevent 'canplay' to fire twice
+				controls.find('.' + t.options.classPrefix + 'time-buffering').hide();
+				// Clear timeout inside 'loadeddata' to prevent 'canplay' from firing twice
+				clearTimeout(media.canplayTimeout);
 			}, false);
 
 			// error handling
@@ -1473,7 +1498,8 @@
 				loading.hide();
 				bigPlay.hide();
 				error.show();
-				error.find('.mejs-overlay-error').html("Error loading this resource");
+				error.find('.' + t.options.classPrefix + 'overlay-error')
+					.html("Error loading this resource");
 			}, false);
 
 			media.addEventListener('keydown', function (e) {
@@ -1491,15 +1517,16 @@
 
 			// listen for key presses
 			t.globalBind('keydown', function (event) {
-				player.hasFocus = $(event.target).closest('.mejs-container').length !== 0 &&
-					$(event.target).closest('.mejs-container').attr('id') === player.$media.closest('.mejs-container').attr('id');
+				var $container = $(event.target).closest('.' + t.options.classPrefix + 'container');
+				player.hasFocus = $container.length !== 0 &&
+					$container.attr('id') === player.$media.closest('.' + t.options.classPrefix + 'container').attr('id');
 				return t.onkeydown(player, media, event);
 			});
 
 
 			// check if someone clicked outside a player region, then kill its focus
 			t.globalBind('click', function (event) {
-				player.hasFocus = $(event.target).closest('.mejs-container').length !== 0;
+				player.hasFocus = $(event.target).closest('.' + t.options.classPrefix + 'container').length !== 0;
 			});
 
 		},
@@ -1545,7 +1572,7 @@
 		changeSkin: function (className) {
 			var t = this;
 
-			t.container[0].className = 'mejs-container ' + className;
+			t.container[0].className = t.options.classPrefix + 'container ' + className;
 			t.setPlayerSize(t.width, t.height);
 			t.setControlsSize();
 		},
@@ -1630,7 +1657,7 @@
 			delete mejs.players[t.id];
 
 			if (typeof t.container === 'object') {
-				t.container.prev('.mejs-offscreen').remove();
+				t.container.prev('.' + t.options.classPrefix + 'offscreen').remove();
 				t.container.remove();
 			}
 			t.globalUnbind();
@@ -1712,9 +1739,10 @@
 		};
 
 
+		// Auto-init using the configured default settings & JSON attribute
 		$(document).ready(function () {
 			// auto enable using JSON attribute
-			$('.mejs-player').mediaelementplayer();
+			$('.' + mejs.MepDefaults.classPrefix + 'player').mediaelementplayer();
 		});
 	}
 

--- a/src/js/mediaelementplayer-simple.js
+++ b/src/js/mediaelementplayer-simple.js
@@ -127,6 +127,7 @@ mejs.getElementsByClassName = getElementsByClassName;
 mejs.id = 1000;
 
 mejs.MediaElementPlayerSimpleDefaults = {
+	classPrefix: 'mejs__',
 	playText: mejs.i18n.t('Play'),
 	pauseText: mejs.i18n.t('Pause')
 };
@@ -164,7 +165,8 @@ function MediaElementPlayerSimple(idOrObj, options) {
 
 	// Container
 	container.id = id + '_container';
-	container.className = 'mejs-simple-container mejs-simple-' + original.tagName.toLowerCase();
+	container.className = mejs.MediaElementPlayerSimpleDefaults.classPrefix + 'simple-container ' +
+	                      mejs.MediaElementPlayerSimpleDefaults.classPrefix + 'simple-' + original.tagName.toLowerCase();
 	container.style.width = originalWidth + 'px';
 	container.style.height = originalHeight + 'px';
 
@@ -222,7 +224,7 @@ MediaElementPlayerSimple.prototype = {
 		;
 
 		// CONTROLS
-		controls.className = 'mejs-simple-controls';
+		controls.className = mejs.MediaElementPlayerSimpleDefaults.classPrefix + 'simple-controls';
 		controls.id = id + '_controls';
 		container.appendChild(controls);
 


### PR DESCRIPTION
...and default to BEM syntax convention. This addresses #1917.

There are probably some remaining questions about how exactly the backwards-compatibility issues will be resolved in practice. These are perhaps better addressed by people with intimate knowledge of the Wordpress update process. Worst case scenario: we could auto-init twice at the bottom of the player, once for the new default class syntax and once for the old 'mejs-'. That's a bit ugly, but it would cover all bases.

This touches a lot of files. I may well have missed something here, but if the basic approach is correct and agreed-upon then I would prefer to get this merged sooner, and implement any fixes on top of this in the coming week.