### PR TITLE
Implement "byte" based pseudo-streaming for FLV playback and seeking

### DIFF
--- a/src/flash/FlashMediaElement.as
+++ b/src/flash/FlashMediaElement.as
@@ -41,6 +41,7 @@ package {
 		private var _streamer:String = "";
 		private var _enablePseudoStreaming:Boolean;
 		private var _pseudoStreamingStartQueryParam:String;
+		private var _pseudoStreamingType:String;
 		private var _fill:Boolean;
 
 		// native video size (from meta data)
@@ -144,6 +145,7 @@ package {
 			_scrubLoadedColor = (params['scrubloadedcolor'] != undefined) ? (String(params['scrubloadedcolor'])) : "0x3CACC8";
 			_enablePseudoStreaming = (params['pseudostreaming'] != undefined) ? (String(params['pseudostreaming']) == "true") : false;
 			_pseudoStreamingStartQueryParam = (params['pseudostreamstart'] != undefined) ? (String(params['pseudostreamstart'])) : "start";
+			_pseudoStreamingType = (params['pseudostreamtype'] != undefined) ? (String(params['pseudostreamtype'])) : "time";
 			_streamer = (params['flashstreamer'] != undefined) ? (String(params['flashstreamer'])) : "";
 			_fill = (params['fill'] != undefined) ? (String(params['fill']) == "true") : false;
 
@@ -218,6 +220,7 @@ package {
 					(_mediaElement as VideoElement).setReference(this);
 					(_mediaElement as VideoElement).setPseudoStreaming(_enablePseudoStreaming);
 					(_mediaElement as VideoElement).setPseudoStreamingStartParam(_pseudoStreamingStartQueryParam);
+					(_mediaElement as VideoElement).setPseudoStreamingType(_pseudoStreamingType);
 					//_video.scaleMode = VideoScaleMode.MAINTAIN_ASPECT_RATIO;
 					addChild(_video);
 				}
@@ -236,6 +239,8 @@ package {
 			logMessage("smoothing: " + _enableSmoothing.toString());
 			logMessage("timerrate: " + _timerRate.toString());
 			logMessage("displayState: " +(stage.hasOwnProperty("displayState")).toString());
+			logMessage("pseudostreaming: " + _enablePseudoStreaming.toString());
+			logMessage("pseudostreamingtype: " + _pseudoStreamingType);
 
 			// attach javascript
 			logMessage("ExternalInterface.available: " + ExternalInterface.available.toString());

--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -31,6 +31,8 @@ mejs.MediaElementDefaults = {
 	enablePseudoStreaming: false,
 	// start query parameter sent to server for pseudo-streaming
 	pseudoStreamingStartQueryParam: 'start',
+	// pseudo streaming type: use `time` for time based seeking (MP4) or `byte` for file byte position (FLV)
+	pseudoStreamingType: 'time',
 	// name of silverlight file
 	silverlightName: 'silverlightmediaelement.xap',
 	// default if the <video width> is not specified
@@ -463,7 +465,8 @@ mejs.HtmlMediaElementShim = {
 				'timerrate=' + options.timerRate,
 				'flashstreamer=' + options.flashStreamer,
 				'height=' + height,
-				'pseudostreamstart=' + options.pseudoStreamingStartQueryParam];
+				'pseudostreamstart=' + options.pseudoStreamingStartQueryParam,
+				'pseudostreamtype=' + options.pseudoStreamingType];
 	
 			if (playback.url !== null) {
 				if (playback.method == 'flash') {


### PR DESCRIPTION
Here is (a very late) PR as requested some months ago : https://github.com/johndyer/mediaelement/pull/1675#issuecomment-241959423

I think this code has been included in some way into the 3.x-dev branch, but this could be nive to have it in the 2.x version as it is still the stable one.

Thanx!