### PR TITLE
Corrected typo in full.js

### DIFF
--- a/full.js
+++ b/full.js
@@ -1,1 +1,1 @@
-module.export = require('./build/mediaelement-and-player.js');
+module.exports = require('./build/mediaelement-and-player.js');


### PR DESCRIPTION
Was working with this library with a project I'm building with webpack. 
I needed to change `module.export` to `module.exports` in /full.js so a call to
`require('mediaelement');` would work.