### PR TITLE
Added error event support in Flash shims

### DIFF
--- a/src/js/renderers/flash.js
+++ b/src/js/renderers/flash.js
@@ -247,7 +247,7 @@ const FlashMediaElementRenderer = {
 		}
 
 		// give initial events like in others renderers
-		const initEvents = ['rendererready', 'loadeddata', 'loadedmetadata', 'canplay'];
+		const initEvents = ['rendererready', 'loadeddata', 'loadedmetadata', 'canplay', 'error'];
 
 		for (i = 0, il = initEvents.length; i < il; i++) {
 			const event = createEvent(initEvents[i], flash);


### PR DESCRIPTION
Now if flash fallback can't initialize (swf not available for example) MediaElement will call error event handler